### PR TITLE
filter ParMETIS dependency, since ParMETIS license doesn't allow redistribution

### DIFF
--- a/EESSI-extend-easybuild.eb
+++ b/EESSI-extend-easybuild.eb
@@ -40,7 +40,7 @@ description = """
 toolchain = SYSTEM
 
 # All the dependencies we filter in EESSI
-local_deps_to_filter = "Autoconf,Automake,Autotools,binutils,bzip2,DBus,flex,gettext,gperf,help2man,intltool,libreadline,libtool,M4,makeinfo,ncurses,util-linux,XZ,zlib"
+local_deps_to_filter ="Autoconf,Automake,Autotools,binutils,bzip2,DBus,flex,gettext,gperf,help2man,intltool,libreadline,libtool,M4,makeinfo,ncurses,ParMETIS,util-linux,XZ,zlib"
 local_arch_specific_deps_to_filter = {'aarch64': ',Yasm', 'riscv64': ',Yasm', 'x86_64': ''}
 local_deps_to_filter += local_arch_specific_deps_to_filter[ARCH]
 

--- a/EESSI-extend-easybuild.eb
+++ b/EESSI-extend-easybuild.eb
@@ -40,7 +40,7 @@ description = """
 toolchain = SYSTEM
 
 # All the dependencies we filter in EESSI
-local_deps_to_filter ="Autoconf,Automake,Autotools,binutils,bzip2,DBus,flex,gettext,gperf,help2man,intltool,libreadline,libtool,M4,makeinfo,ncurses,ParMETIS,util-linux,XZ,zlib"
+local_deps_to_filter = "Autoconf,Automake,Autotools,binutils,bzip2,DBus,flex,gettext,gperf,help2man,intltool,libreadline,libtool,M4,makeinfo,ncurses,ParMETIS,util-linux,XZ,zlib"
 local_arch_specific_deps_to_filter = {'aarch64': ',Yasm', 'riscv64': ',Yasm', 'x86_64': ''}
 local_deps_to_filter += local_arch_specific_deps_to_filter[ARCH]
 

--- a/configure_easybuild
+++ b/configure_easybuild
@@ -44,7 +44,7 @@ fi
 
 # note: filtering Bison may break some installations, like Qt5 (see https://github.com/EESSI/software-layer/issues/49)
 # filtering pkg-config breaks R-bundle-Bioconductor installation (see also https://github.com/easybuilders/easybuild-easyconfigs/pull/11104)
-DEPS_TO_FILTER=Autoconf,Automake,Autotools,binutils,bzip2,DBus,flex,gettext,gperf,help2man,intltool,libreadline,libtool,M4,makeinfo,ncurses,util-linux,XZ,zlib
+DEPS_TO_FILTER=Autoconf,Automake,Autotools,binutils,bzip2,DBus,flex,gettext,gperf,help2man,intltool,libreadline,libtool,M4,makeinfo,ncurses,ParMETIS,util-linux,XZ,zlib
 # For aarch64 we need to also filter out Yasm.
 # See https://github.com/easybuilders/easybuild-easyconfigs/issues/11190
 if [[ "$EESSI_CPU_FAMILY" == "aarch64" ]]; then

--- a/easystacks/software.eessi.io/2023.06/rebuilds/20250612-eb-5.1.0-EESSI-extend-filter-ParMETIS.yml
+++ b/easystacks/software.eessi.io/2023.06/rebuilds/20250612-eb-5.1.0-EESSI-extend-filter-ParMETIS.yml
@@ -1,5 +1,0 @@
-# 2024.06.12
-# Rebuild required because EasyBuild configuration was updated to filter ParMETIS dependency
-# see https://github.com/EESSI/software-layer-scripts/pull/2
-easyconfigs:
-  - EESSI-extend-easybuild.eb

--- a/easystacks/software.eessi.io/2023.06/rebuilds/20250612-eb-5.1.0-EESSI-extend-filter-ParMETIS.yml
+++ b/easystacks/software.eessi.io/2023.06/rebuilds/20250612-eb-5.1.0-EESSI-extend-filter-ParMETIS.yml
@@ -1,0 +1,5 @@
+# 2024.06.12
+# Rebuild required because EasyBuild configuration was updated to filter ParMETIS dependency
+# see https://github.com/EESSI/software-layer-scripts/pull/2
+easyconfigs:
+  - EESSI-extend-easybuild.eb

--- a/load_eessi_extend_module.sh
+++ b/load_eessi_extend_module.sh
@@ -117,7 +117,7 @@ if [ "${install_eessi_extend}" = true ] || [ "${rebuild_eessi_extend}" = true ];
 
         # while always adding --try-amend=keep... may do no harm, we could make
         # an attempt to figure out if it is needed, e.g., when we are rebuilding
-        eb_args="--try-amend=keeppreviousinstall=True "
+        eb_args=""
         if [ "${rebuild_eessi_extend}" = true ]; then
             eb_args+="--rebuild"
         fi

--- a/load_eessi_extend_module.sh
+++ b/load_eessi_extend_module.sh
@@ -24,6 +24,8 @@
 #
 set -o pipefail
 
+EESSI_EXTEND_EASYCONFIG="EESSI-extend-easybuild.eb"
+
 # this script is *sourced*, not executed, so can't rely on $0 to determine path to self or script name
 # $BASH_SOURCE points to correct path or script name, see also http://mywiki.wooledge.org/BashFAQ/028
 if [ $# -ne 1 ]; then
@@ -65,11 +67,25 @@ ml_av_eessi_extend_out=${TMPDIR}/ml_av_eessi_extend.out
 # need to use --ignore_cache to avoid the case that the module was removed (to be
 # rebuilt) but it is still in the cache
 module --ignore_cache avail 2>&1 | grep -i EESSI-extend/${EESSI_EXTEND_VERSION} &> ${ml_av_eessi_extend_out}
-
 if [[ $? -eq 0 ]]; then
     echo_green ">> Module for EESSI-extend/${EESSI_EXTEND_VERSION} found!"
+    install_eessi_extend=false
+    rebuild_eessi_extend=false
+    # $PR_DIFF should be set by the calling script (EESSI-install-software.sh)
+    if [[ ! -z ${PR_DIFF} ]] && [[ -f "$PR_DIFF" ]]; then
+        # check if EESSI-extend easyconfig was modified; if so, we need to rebuild it
+        grep -q "^\+\+\+ b/${EESSI_EXTEND_EASYCONFIG}" "${PR_DIFF}"
+        if [[ $? -eq 0 ]]; then
+            rebuild_eessi_extend=true
+        fi
+    fi
 else
     echo_yellow ">> No module yet for EESSI-extend/${EESSI_EXTEND_VERSION}, installing it..."
+    install_eessi_extend=true
+    rebuild_eessi_extend=false
+fi
+
+if [ "${install_eessi_extend}" = true ] || [ "${rebuild_eessi_extend}" = true ]; then
 
     EB_TMPDIR=${TMPDIR}/ebtmp
     echo ">> Using temporary installation of EasyBuild (in ${EB_TMPDIR})..."
@@ -98,9 +114,15 @@ else
         eessi_install_out=${TMPDIR}/eessi_install.out
         ok_msg="EESSI-extend/${EESSI_EXTEND_VERSION} installed, let's go!"
         fail_msg="Installing EESSI-extend/${EESSI_EXTEND_VERSION} failed, that's not good... (output: ${eessi_install_out})"
+
         # while always adding --try-amend=keep... may do no harm, we could make
         # an attempt to figure out if it is needed, e.g., when we are rebuilding
-        ${EB} "EESSI-extend-easybuild.eb" --try-amend=keeppreviousinstall=True 2>&1 | tee ${eessi_install_out}
+        eb_args="--try-amend=keeppreviousinstall=True "
+        if [ "${rebuild_eessi_extend}" = true ]; then
+            eb_args+="--rebuild"
+        fi
+        echo ">> Installing EESSI-extend with '${EB} ${eb_args} ${EESSI_EXTEND_EASYCONFIG}'..."
+        ${EB} ${eb_args} "${EESSI_EXTEND_EASYCONFIG}" 2>&1 | tee ${eessi_install_out}
         check_exit_code $? "${ok_msg}" "${fail_msg}"
     )
 


### PR DESCRIPTION
We should also remove the `ParMETIS/4.0.3-gompi-2023a` installation that was ingested a while ago, and rebuild the modules that have already been ingested that depend on `ParMETIS`.

We should probably also put a check in place to make sure that `ParMETIS` itself also never gets added explicitly, via a blocklist based on software names in EasyBuild hooks? (let's do that in a separate PR)