### PR TITLE
always copy script if it doesn't exist yet at destination

### DIFF
--- a/install_scripts.sh
+++ b/install_scripts.sh
@@ -49,8 +49,12 @@ compare_and_copy() {
     if [ ! -f "$destination_file" ] || ! diff -q "$source_file" "$destination_file" ; then
         echo "Files $source_file and $destination_file differ, checking if we should copy or not"
         # We only copy if the file is part of the PR
-        if file_changed_in_pr "$source_file"; then
-          echo "File has changed in the PR"
+        if [ ! -f "${destination_file}" ] || file_changed_in_pr "$source_file"; then
+          if [ ! -f "${destination_file}" ]; then
+            echo "File has not been copied yet ($destination_file does not exist}"
+          else
+            echo "File has changed in the PR"
+          fi
           cp "$source_file" "$destination_file"
           echo "File $source_file copied to $destination_file"
         else


### PR DESCRIPTION
Follow-up for https://github.com/EESSI/software-layer/pull/1119, which assumes that files are already copied, they may not be yet.

I hit this when starting to put things in place for EESSI 2025.06, see https://github.com/EESSI/software-layer-scripts/pull/6