### PR TITLE
Make sure the full directory name is replaced in `eb_hooks.py`, replace placeholders before comparing what is shipped

### DIFF
--- a/bot/test.sh
+++ b/bot/test.sh
@@ -151,12 +151,13 @@ EESSI_REPOS_CFG_DIR_OVERRIDE=$(cfg_get_value "repository" "repos_cfg_dir")
 export EESSI_REPOS_CFG_DIR_OVERRIDE=${EESSI_REPOS_CFG_DIR_OVERRIDE:-${PWD}/cfg}
 echo "bot/test.sh: EESSI_REPOS_CFG_DIR_OVERRIDE='${EESSI_REPOS_CFG_DIR_OVERRIDE}'"
 
-# determine pilot version to be used from .repository.repo_version in ${JOB_CFG_FILE}
-# here, just set & export EESSI_PILOT_VERSION_OVERRIDE
+# determine EESSI version to be used from .repository.repo_version in ${JOB_CFG_FILE}
+# here, just set & export EESSI_VERSION_OVERRIDE
 # next script (eessi_container.sh) makes use of it via sourcing init scripts
 # (e.g., init/eessi_defaults or init/minimal_eessi_env)
-export EESSI_PILOT_VERSION_OVERRIDE=$(cfg_get_value "repository" "repo_version")
-echo "bot/test.sh: EESSI_PILOT_VERSION_OVERRIDE='${EESSI_PILOT_VERSION_OVERRIDE}'"
+REPOSITORY_VERSION=$(cfg_get_value "repository" "repo_version")
+export EESSI_VERSION_OVERRIDE=${REPOSITORY_VERSION}
+echo "bot/build.sh: EESSI_VERSION_OVERRIDE='${EESSI_VERSION_OVERRIDE}'"
 
 # determine CVMFS repo to be used from .repository.repo_name in ${JOB_CFG_FILE}
 # here, just set EESSI_CVMFS_REPO_OVERRIDE, a bit further down

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -405,7 +405,7 @@ def parse_hook_zen4_module_only(ec, eprefix):
         env_varname = EESSI_IGNORE_ZEN4_GCC1220_ENVVAR
         # TODO: create a docs page to which we can refer for more info here
         # TODO: then update the link to the known issues page to the _specific_ issue
-        # Need to escape newline character so that the newline character actually ends up in the module file
+        # Need to escape the newline character so that the newline character actually ends up in the module file
         # (otherwise, it splits the string, and a 2-line string ends up in the modulefile, resulting in syntax error)
         errmsg = "EasyConfigs using toolchains based on GCCcore-12.2.0 are not supported for the Zen4 architecture.\\n"
         errmsg += "See https://www.eessi.io/docs/known_issues/eessi-<EESSI_VERSION>/#gcc-1220-and-foss-2022b-based-modules-cannot-be-loaded-on-zen4-architecture"

--- a/install_scripts.sh
+++ b/install_scripts.sh
@@ -204,4 +204,4 @@ done
 sed -i "s@/<EESSI_VERSION>/@/${EESSI_VERSION}/@g" ${INSTALL_PREFIX}/init/modules/EESSI/${EESSI_VERSION}.lua
 
 # replace EESSI version used in EasyBuild hooks
-sed -i "s@/<EESSI_VERSION>/@/${EESSI_VERSION}/@g" ${INSTALL_PREFIX}/init/easybuild/eb_hooks.py
+sed -i "s@/eessi-<EESSI_VERSION>/@/eessi-${EESSI_VERSION}/@g" ${INSTALL_PREFIX}/init/easybuild/eb_hooks.py

--- a/install_scripts.sh
+++ b/install_scripts.sh
@@ -136,7 +136,6 @@ init_files=(
 )
 # make sure that scripts in init/ and scripts/ use correct EESSI version
 sed -i "s/__EESSI_VERSION_DEFAULT__/${EESSI_VERSION}/g" ${TOPDIR}/init/eessi_defaults
-
 copy_files_by_list ${TOPDIR}/init ${INSTALL_PREFIX}/init "${init_files[@]}"
 
 # Copy for the init/arch_specs directory

--- a/install_scripts.sh
+++ b/install_scripts.sh
@@ -57,9 +57,9 @@ sed_update_if_changed() {
     if ! diff -q "$file" "$tmp_file" > /dev/null; then
         # Use cat to retain existing permissions, set umask to world readable in case the target file does not yet exist. 
         (umask 022 && cat "$tmp_file" > "$file")
-    else
-        rm -f "$tmp_file"
     fi
+    # Remove the temporary file
+    rm -f "$tmp_file"
 }
 
 compare_and_copy() {

--- a/install_scripts.sh
+++ b/install_scripts.sh
@@ -134,6 +134,9 @@ init_files=(
     minimal_eessi_env README.md test.py lmod_eessi_archdetect_wrapper.sh lmod_eessi_archdetect_wrapper_accel.sh
 
 )
+# make sure that scripts in init/ and scripts/ use correct EESSI version
+sed -i "s/__EESSI_VERSION_DEFAULT__/${EESSI_VERSION}/g" ${TOPDIR}/init/eessi_defaults
+
 copy_files_by_list ${TOPDIR}/init ${INSTALL_PREFIX}/init "${init_files[@]}"
 
 # Copy for the init/arch_specs directory
@@ -152,12 +155,16 @@ copy_files_by_list ${TOPDIR}/init/Magic_Castle ${INSTALL_PREFIX}/init/Magic_Cast
 mc_files=(
    2023.06.lua
 )
+# replace EESSI version used in comments in EESSI module
+sed -i "s@/<EESSI_VERSION>/@/${EESSI_VERSION}/@g" ${TOPDIR}/init/modules/EESSI/${EESSI_VERSION}.lua
 copy_files_by_list ${TOPDIR}/init/modules/EESSI ${INSTALL_PREFIX}/init/modules/EESSI "${mc_files[@]}"
 
 # Copy for init/lmod directory
-init_script_files=(
-    bash zsh ksh fish csh    
-)
+init_script_files=$(ls ${TOPDIR}/init/lmod)
+# replace placeholder for default EESSI version in Lmod init scripts
+for shell in $init_script_files; do
+    sed -i "s/__EESSI_VERSION_DEFAULT__/${EESSI_VERSION}/g" ${TOPDIR}/init/lmod/${shell}
+done
 copy_files_by_list ${TOPDIR}/init/lmod ${INSTALL_PREFIX}/init/lmod "${init_script_files[@]}"
 
 # Copy for the scripts directory
@@ -186,22 +193,6 @@ ${INSTALL_PREFIX}/scripts/gpu_support/nvidia/easystacks "${host_injections_easys
 hook_files=(
     eb_hooks.py
 )
-copy_files_by_list ${TOPDIR} ${INSTALL_PREFIX}/init/easybuild "${hook_files[@]}"
-
-# replace version placeholders in scripts;
-# note: the commands below are always run, regardless of whether the scripts were changed,
-# but that should be fine (no changes are made if version placeholder is not present anymore)
-
-# make sure that scripts in init/ and scripts/ use correct EESSI version
-sed -i "s/__EESSI_VERSION_DEFAULT__/${EESSI_VERSION}/g" ${INSTALL_PREFIX}/init/eessi_defaults
-
-# replace placeholder for default EESSI version in Lmod init scripts
-for shell in $(ls ${INSTALL_PREFIX}/init/lmod); do
-    sed -i "s/__EESSI_VERSION_DEFAULT__/${EESSI_VERSION}/g" ${INSTALL_PREFIX}/init/lmod/${shell}
-done
-
-# replace EESSI version used in comments in EESSI module
-sed -i "s@/<EESSI_VERSION>/@/${EESSI_VERSION}/@g" ${INSTALL_PREFIX}/init/modules/EESSI/${EESSI_VERSION}.lua
-
 # replace EESSI version used in EasyBuild hooks
-sed -i "s@/eessi-<EESSI_VERSION>/@/eessi-${EESSI_VERSION}/@g" ${INSTALL_PREFIX}/init/easybuild/eb_hooks.py
+sed -i "s@/eessi-<EESSI_VERSION>/@/eessi-${EESSI_VERSION}/@g" ${TOPDIR}/eb_hooks.py
+copy_files_by_list ${TOPDIR} ${INSTALL_PREFIX}/init/easybuild "${hook_files[@]}"

--- a/install_scripts.sh
+++ b/install_scripts.sh
@@ -55,7 +55,8 @@ sed_update_if_changed() {
     }
 
     if ! diff -q "$file" "$tmp_file" > /dev/null; then
-        mv "$tmp_file" "$file"
+        # Use cat to retain existing permissions, set umask to world readable in case the target file does not yet exist. 
+        (umask 022 && cat "$tmp_file" > "$file")
     else
         rm -f "$tmp_file"
     fi

--- a/install_scripts.sh
+++ b/install_scripts.sh
@@ -54,7 +54,7 @@ sed_update_if_changed() {
         return 1
     }
 
-    if ! cmp -s "$file" "$tmp_file"; then
+    if ! diff -q "$file" "$tmp_file" > /dev/null; then
         mv "$tmp_file" "$file"
     else
         rm -f "$tmp_file"

--- a/install_scripts.sh
+++ b/install_scripts.sh
@@ -228,4 +228,4 @@ done
 sed_update_if_changed "s@/<EESSI_VERSION>/@/${EESSI_VERSION}/@g" ${INSTALL_PREFIX}/init/modules/EESSI/${EESSI_VERSION}.lua
 
 # replace EESSI version used in EasyBuild hooks
-sed_update_if_changed "s@/<EESSI_VERSION>/@/${EESSI_VERSION}/@g" ${INSTALL_PREFIX}/init/easybuild/eb_hooks.py
+sed_update_if_changed "s@/eessi-<EESSI_VERSION>/@/eessi-${EESSI_VERSION}/@g" ${INSTALL_PREFIX}/init/easybuild/eb_hooks.py


### PR DESCRIPTION
This was basically a typo in #11 

That PR also creates problems though through the use of `sed -i` as this always updates the timestamps on the files, causing any file where it was used to also be shipped. Resolved this by creating a bash function that is more careful.

Finally, that PR also "broke" the test script as that script was not correctly picking up the EESSI version, this is also fixed here.