### PR TITLE
filter whiteout files with `find` (instead of using `grep`) in `create_tarball.sh`

### DIFF
--- a/create_tarball.sh
+++ b/create_tarball.sh
@@ -85,8 +85,7 @@ for subdir in ${cpu_arch_subdir} ${cpu_arch_subdir}/accel/${accel_subdir}; do
         # installation directories), the procedure will likely not work.
         for package_version in $(cat ${module_files_list}); do
             echo "handling ${package_version}"
-            ls -d ${eessi_version}/software/${os}/${subdir}/software/${package_version} \
-                | grep -v '/\.wh\.' >> ${files_list} || true  # Make sure we don't exit because of set -e if grep doesn't return a match
+            find ${eessi_version}/software/${os}/${subdir}/software/${package_version} -maxdepth 0 -type d \! -name '.wh.*' >> ${files_list}
         done
     fi
 done


### PR DESCRIPTION
This should solve the issues in the tarball creation steps that we see in for instance https://github.com/EESSI/software-layer/pull/1131. There are some emtpy directories in the `init` folder, and then the `grep` returns 1. By adding `|| true` (we already did that for a few other `grep` commands) it will always return 0.


edit: instead of adding `|| true` to the `grep` command, we decided to add an option to the `find` command for excluding whiteout files.