### PR TITLE
use `unionfs` overlay tool (+ debian12 build container that includes it) by default

### DIFF
--- a/.github/workflows/test_eessi_container_script.yml
+++ b/.github/workflows/test_eessi_container_script.yml
@@ -41,7 +41,7 @@ jobs:
         - name: Test eessi_container.sh script
           run: |
               test_cmd="cat /etc/os-release"
-              out_pattern="Debian GNU/Linux 11"
+              out_pattern="Debian GNU/Linux 12"
 
               if [[ ${{matrix.SCRIPT_TEST}} == 'help' ]]; then
                 ./eessi_container.sh --help
@@ -116,7 +116,7 @@ jobs:
                 rm -f ${outfile}
 
                 # make sure that container image exists
-                test -f ${tmpdir}/ghcr.io_eessi_build_node_debian11.sif || (echo "Container image not found in ${tmpdir}" >&2 && ls ${tmpdir} && exit 1)
+                test -f ${tmpdir}/ghcr.io_eessi_build_node_debian12.sif || (echo "Container image not found in ${tmpdir}" >&2 && ls ${tmpdir} && exit 1)
 
                 ./eessi_container.sh --verbose --resume ${tmpdir} --mode shell <<< "${test_cmd}" > ${outfile}
                 cat ${outfile}

--- a/eessi_container.sh
+++ b/eessi_container.sh
@@ -77,7 +77,7 @@ display_help() {
   echo "                            To specify multiple bind paths, separate by comma."
   echo "                            Example: '/src:/dest:ro,/src2:/dest2:rw'"
   echo "  -c | --container IMG    - image file or URL defining the container to use"
-  echo "                            [default: docker://ghcr.io/eessi/build-node:debian11]"
+  echo "                            [default: docker://ghcr.io/eessi/build-node:debian12]"
   echo "  -f | --fakeroot         - run the container with --fakeroot [default: false]"
   echo "  -g | --storage DIR      - directory space on host machine (used for"
   echo "                            temporary data) [default: 1. TMPDIR, 2. /tmp]"
@@ -92,7 +92,7 @@ display_help() {
   echo "                            attach a GPU, MODE==all for both [default: false]"
   echo "  -o | --overlay-tool ARG - tool to use to create (read-only or writable) overlay;"
   echo "                            selected tool *must* be available in container image being used;"
-  echo "                            can be 'fuse-overlayfs' or 'unionfs' [default: fuse-overlayfs]"
+  echo "                            can be 'fuse-overlayfs' or 'unionfs' [default: unionfs]"
   echo "  -p | --pass-through ARG - argument to pass through to the launch of the"
   echo "                            container; can be given multiple times [default: not set]"
   echo "  -r | --repository CFG   - configuration file or identifier defining the"
@@ -125,14 +125,14 @@ display_help() {
 
 # set defaults for command line arguments
 ACCESS="ro"
-CONTAINER="docker://ghcr.io/eessi/build-node:debian11"
+CONTAINER="docker://ghcr.io/eessi/build-node:debian12"
 #DRY_RUN=0
 FAKEROOT=0
 VERBOSE=0
 STORAGE=
 LIST_REPOS=0
 MODE="shell"
-OVERLAY_TOOL="fuse-overlayfs"
+OVERLAY_TOOL="unionfs"
 PASS_THROUGH=()
 SETUP_NVIDIA=0
 REPOSITORIES=()


### PR DESCRIPTION
Follow-up for:
* #9

As discussed during today's EESSI support sync meeting, let's change the default to use `unionfs` rather than `fuse-overlayfs` to create a writable overlay for building software to be ingested into EESSI.

This should circumvent the problems we have with `fuse-overlayfs` when doing rebuilds, see also https://github.com/EESSI/software-layer/issues/556 and https://github.com/EESSI/software-layer/issues/1103