### PR TITLE
Fix `stray \ before +` error caused by `grep` in `load_eessi_extend_module.sh`

### DIFF
--- a/load_eessi_extend_module.sh
+++ b/load_eessi_extend_module.sh
@@ -74,7 +74,7 @@ if [[ $? -eq 0 ]]; then
     # $PR_DIFF should be set by the calling script (EESSI-install-software.sh)
     if [[ ! -z ${PR_DIFF} ]] && [[ -f "$PR_DIFF" ]]; then
         # check if EESSI-extend easyconfig was modified; if so, we need to rebuild it
-        grep -q "^\+\+\+ b/${EESSI_EXTEND_EASYCONFIG}" "${PR_DIFF}"
+        grep -q "^+++ b/${EESSI_EXTEND_EASYCONFIG}" "${PR_DIFF}"
         if [[ $? -eq 0 ]]; then
             rebuild_eessi_extend=true
         fi


### PR DESCRIPTION
While inspecting the log of a build done in #27, I found this warning:
```
grep: warning: stray \ before +
```

It's caused by a `grep` in `load_eessi_extend_module.sh`, and can be reproduced with the `grep` from our compat layer:
```
$ /cvmfs/software.eessi.io/versions/2023.06/compat/linux/x86_64/startprefix 
Entering Gentoo Prefix /cvmfs/software.eessi.io/versions/2023.06/compat/linux/x86_64

$ echo "+++ b/EESSI-extend" | grep "^\+\+\+ b/"
grep: warning: stray \ before +
+++ b/EESSI-extend
```

But it shouldn't be necessary to escape the `+`:
```
$ echo "+++ b/EESSI-extend" | grep "^+++ b/"
+++ b/EESSI-extend
```