### PR TITLE
enclose `accel_subdir` variable in double quotes

### DIFF
--- a/create_tarball.sh
+++ b/create_tarball.sh
@@ -64,7 +64,7 @@ fi
 
 # consider both CPU-only and accelerator subdirectories (if an accelerator was configured)
 sw_subdirs=${cpu_arch_subdir}
-if [ -n ${accel_subdir} ]; then
+if [ -n "${accel_subdir}" ]; then
     sw_subdirs="${sw_subdirs} ${cpu_arch_subdir}/${accel_subdir}"
 fi
 for subdir in ${sw_subdirs}; do


### PR DESCRIPTION
Without this fix, it would still loop over `${cpu_arch_subdir}/${accel_subdir}`, even though `accel_subdir` is an empty string:
```
$ a=""
$ [ -n "${a}" ] && echo "test"
$ [ -n ${a} ] && echo "test"
test
```
This causes files to appear twice in the tarball, once with a single slash and once with a double slash. And that messes up the tarball overview generated by the bot.