### PR TITLE
Fix permission issue for newly created dirs/files in `install_scripts.sh`

### DIFF
--- a/install_scripts.sh
+++ b/install_scripts.sh
@@ -80,7 +80,8 @@ compare_and_copy() {
           else
             echo "File has changed in the PR"
           fi
-          cp "$source_file" "$destination_file"
+          # Use cat to retain existing permissions, set umask to world readable in case the target file does not yet exist.
+          (umask 022 && cat "$source_file" > "$destination_file")
           echo "File $source_file copied to $destination_file"
         else
           case $? in


### PR DESCRIPTION
This issue surfaced when building the init dir for the new 2025.06 version, and only on Deucalion: the permissions on the `init/bash` and `modules/EESSI/2025.lua` files were wrong, and didn't have read permissions for others. I suspect it's related to the default umask on Deucalion (?). 

I noticed that `install_scripts.sh` already used a special procedure in `sed_update_if_changed` (see https://github.com/EESSI/software-layer-scripts/blob/main/install_scripts.sh#L58), which explicitly sets the umask and uses `cat` for copying the files (apparently to retain the permissions?). This PR uses the same approach for copying missing/modified files (instead of using `cp`). https://github.com/EESSI/software-layer-scripts/pull/37#issuecomment-3073310086 shows that this solves the issue on Deucalion.