### PR TITLE
print warning about `post_easyblock_hook` to stderr

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-001-system.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-001-system.yml
@@ -1,4 +1,0 @@
-easyconfigs:
-  - cowsay-3.04.eb:
-      options:
-        try-software-version: 999

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-001-system.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-001-system.yml
@@ -1,2 +1,4 @@
 easyconfigs:
-  - cowsay-3.04.eb
+  - cowsay-3.04.eb:
+      options:
+        try-software-version: 999

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-001-system.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-001-system.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - cowsay-3.04.eb

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -9,7 +9,7 @@ import easybuild.tools.environment as env
 from easybuild.easyblocks.generic.configuremake import obtain_config_guess
 from easybuild.framework.easyconfig.constants import EASYCONFIG_CONSTANTS
 from easybuild.tools import config
-from easybuild.tools.build_log import EasyBuildError, print_msg
+from easybuild.tools.build_log import EasyBuildError, print_msg, print_warning
 from easybuild.tools.config import build_option, install_path, update_build_option
 from easybuild.tools.filetools import apply_regex_substitutions, copy_dir, copy_file, remove_file, symlink, which
 from easybuild.tools.run import run_cmd
@@ -1331,7 +1331,7 @@ if EASYBUILD_VERSION >= '5.1.1':
         else:
             self.log.debug("No CVMFS/site installation requested, not running post_easyblock_hook_copy_easybuild_subdir.")
 else:
-    print_msg(f"Not enabling the post_easybuild_hook, as it requires EasyBuild 5.1.1 or newer.")
+    print_warning(f"Not enabling the post_easybuild_hook, as it requires EasyBuild 5.1.1 or newer (you are using {EASYBUILD_VERSION}).")
 
 
 PARSE_HOOKS = {


### PR DESCRIPTION
I saw the following in a Slurm log of a failed build, done with EB 4.9.x:
```
cp: cannot stat '==': No such file or directory
cp: cannot stat 'Not': No such file or directory
cp: cannot stat 'enabling': No such file or directory
cp: cannot stat 'the': No such file or directory
cp: cannot stat 'post_easybuild_hook,': No such file or directory
cp: cannot stat 'as': No such file or directory
cp: cannot stat 'it': No such file or directory
cp: cannot stat 'requires': No such file or directory
cp: cannot stat 'EasyBuild': No such file or directory
cp: cannot stat '5.1.1': No such file or directory
cp: cannot stat 'or': No such file or directory
cp: cannot stat 'newer.': No such file or directory
Last EasyBuild log file copied from == Not enabling the post_easybuild_hook, as it requires EasyBuild 5.1.1 or newer.
```

This is because `eb --last-log` also prints `Not enabling the post_easybuild_hook, as it requires EasyBuild 5.1.1 or newer.`, because it's not inside a hook function. By printing it to stderr, the issue is solved, as can be easily tested with `EESSI-extend`:
```
$ ml EasyBuild/5.0.0 EESSI-extend
$ eb --last-log
== Not enabling the post_easybuild_hook, as it requires EasyBuild 5.1.1 or newer.
/tmp/eb-mvh76a14/easybuild-dv862upj.log
$ echo $l
== Not enabling the post_easybuild_hook, as it requires EasyBuild 5.1.1 or newer. /tmp/eb-mvh76a14/easybuild-dv862upj.log

# use the hooks file from this PR
$ export EASYBUILD_HOOKS=./eb_hooks.py
$ l=$(eb --last-log)

WARNING: Not enabling the post_easybuild_hook, as it requires EasyBuild 5.1.1 or newer (you are using 5.0.0).

$ echo $l
/tmp/eb-mvh76a14/easybuild-dv862upj.log
```
