### PR TITLE
Allow end users to add a family name to the EESSI module

### DIFF
--- a/.github/workflows/tests_eessi_module.yml
+++ b/.github/workflows/tests_eessi_module.yml
@@ -303,7 +303,7 @@ jobs:
           mkdir -p "${TMP_MODULEFILES}/${LOCAL_STACK_NAME}"
           echo "family(\"${FAMILY}\")" > "${TMP_MODULEFILES}/${LOCAL_STACK_NAME}/${LOCAL_STACK_VERSION}.lua"
 
-          # Make sure we are using the EESSImodule file from the repository and the temporary one for the dummy local stack
+          # Make sure we are using the EESSI module file from the repository and the temporary one for the dummy local stack
           export MODULEPATH=init/modules:${TMP_MODULEFILES}
 
           # Set the relevant environment variable, load the EESSI module and the local stack module, and grep for

--- a/.github/workflows/tests_eessi_module.yml
+++ b/.github/workflows/tests_eessi_module.yml
@@ -301,7 +301,7 @@ jobs:
           LOCAL_STACK_NAME="local_stack"
           LOCAL_STACK_VERSION="${{matrix.EESSI_VERSION}}"
           mkdir -p "${TMP_MODULEFILES}/${LOCAL_STACK_NAME}"
-          echo "family(\"${FAMILY}\")" > "${TMP_MODULEFILES}/${LOCAL_STACK_NAME}/${LOCAL_STACK_VERSION}"
+          echo "family(\"${FAMILY}\")" > "${TMP_MODULEFILES}/${LOCAL_STACK_NAME}/${LOCAL_STACK_VERSION}.lua"
 
           # Make sure we are using the EESSImodule file from the repository and the temporary one for the dummy local stack
           export MODULEPATH=init/modules:${TMP_MODULEFILES}

--- a/.github/workflows/tests_eessi_module.yml
+++ b/.github/workflows/tests_eessi_module.yml
@@ -258,7 +258,7 @@ jobs:
           # Initialise Lmod
           . /cvmfs/software.eessi.io/versions/${{matrix.EESSI_VERSION}}/compat/linux/$(uname -m)/usr/share/Lmod/init/bash
           
-          # Make sure we using the module file from the repository
+          # Make sure we are using the module file from the repository
           export MODULEPATH=init/modules
           
           # Set the relevant environment variable and load the EESSI module
@@ -269,3 +269,46 @@ jobs:
           # Purge and check the module is still loaded
           module purge
           module list |& grep "EESSI/${{matrix.EESSI_VERSION}}"
+
+  check_family_eessi_module:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        EESSI_VERSION:
+          - '2023.06'
+          - '2025.06'
+
+    steps:
+      - name: Check out software-layer repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Mount EESSI CernVM-FS repository
+        uses: cvmfs-contrib/github-action-cvmfs@55899ca74cf78ab874bdf47f5a804e47c198743c # v4.0
+        with:
+          cvmfs_config_package: https://github.com/EESSI/filesystem-layer/releases/download/latest/cvmfs-config-eessi_latest_all.deb
+          cvmfs_http_proxy: DIRECT
+          cvmfs_repositories: software.eessi.io
+
+      - name: Make sure we can use the family directive in the EESSI module
+        run: |
+          # Initialise Lmod
+          . /cvmfs/software.eessi.io/versions/${{matrix.EESSI_VERSION}}/compat/linux/$(uname -m)/usr/share/Lmod/init/bash
+
+          # Add a test modulefile for a dummy stack with a "software_stack" family directive
+          FAMILY=software_stack
+          TMP_MODULEFILES=$(mktemp -d)
+          LOCAL_STACK_NAME="local_stack"
+          LOCAL_STACK_VERSION="${{matrix.EESSI_VERSION}}"
+          mkdir -p "${TMP_MODULEFILES}/${LOCAL_STACK_NAME}"
+          echo "family(\"${FAMILY}\")" > "${TMP_MODULEFILES}/${LOCAL_STACK_NAME}/${LOCAL_STACK_VERSION}"
+
+          # Make sure we are using the EESSImodule file from the repository and the temporary one for the dummy local stack
+          export MODULEPATH=init/modules:${TMP_MODULEFILES}
+
+          # Set the relevant environment variable, load the EESSI module and the local stack module, and grep for
+          # Lmod is automatically replacing "..." with "...".
+          export EESSI_MODULE_FAMILY_NAME=${FAMILY}
+          module load "EESSI/${{matrix.EESSI_VERSION}}"
+          GREP_PATTERN="Lmod is automatically replacing \"EESSI/${{matrix.EESSI_VERSION}}" with \"${LOCAL_STACK_NAME}/${LOCAL_STACK_VERSION}\"."
+          module load "${LOCAL_STACK_NAME}/${LOCAL_STACK_VERSION}" |& grep "${GREP_PATTERN}"

--- a/.github/workflows/tests_eessi_module.yml
+++ b/.github/workflows/tests_eessi_module.yml
@@ -310,5 +310,5 @@ jobs:
           # Lmod is automatically replacing "..." with "...".
           export EESSI_MODULE_FAMILY_NAME=${FAMILY}
           module load "EESSI/${{matrix.EESSI_VERSION}}"
-          GREP_PATTERN="Lmod is automatically replacing \"EESSI/${{matrix.EESSI_VERSION}}" with \"${LOCAL_STACK_NAME}/${LOCAL_STACK_VERSION}\"."
+          GREP_PATTERN="Lmod is automatically replacing \"EESSI/${{matrix.EESSI_VERSION}}\" with \"${LOCAL_STACK_NAME}/${LOCAL_STACK_VERSION}\"."
           module load "${LOCAL_STACK_NAME}/${LOCAL_STACK_VERSION}" |& grep "${GREP_PATTERN}"

--- a/init/modules/EESSI/2023.06.lua
+++ b/init/modules/EESSI/2023.06.lua
@@ -173,6 +173,13 @@ if isDir(eessi_module_path_accel) then
     eessiDebug("Using site accelerator modules at: " .. eessi_module_path_site_accel)
 end
 
+-- allow sites to add a family directive to the EESSI module,
+-- e.g. for preventing that users load two different/incompatible stacks at the same time
+family_name = os.getenv("EESSI_MODULE_FAMILY_NAME")
+if family_name then
+    family(family_name)
+end
+
 -- allow sites to make the EESSI module sticky by defining EESSI_MODULE_STICKY (to any value)
 load_message = "Module for EESSI/" .. eessi_version .. " loaded successfully"
 if os.getenv("EESSI_MODULE_STICKY") then


### PR DESCRIPTION
Assuming sites have a `family("stack")` in the meta module for the local stack, this allows them to do the following:

```
$ export EESSI_MODULE_FAMILY_NAME=stack
$ ml EESSI/2023.06
$ ml mystack/1.2.3

Lmod is automatically replacing "EESSI/2023.06" with "mystack/1.2.3".
```