### PR TITLE
Fix upload for multiple GPU targets

### DIFF
--- a/bot/build.sh
+++ b/bot/build.sh
@@ -267,11 +267,11 @@ TARBALL_STEP_ARGS+=("--resume" "${BUILD_TMPDIR}")
 timestamp=$(date +%s)
 # to set EESSI_VERSION we need to source init/eessi_defaults now
 source $software_layer_dir/init/eessi_defaults
-# Note: iff ${EESSI_DEV_PROJECT} is defined (building for dev.eessi.io), then we 
+# Note: if ${EESSI_DEV_PROJECT} is defined (building for dev.eessi.io), then we 
 # append the project (subdirectory) name to the end tarball name. This is information
 # then used at the ingestion stage. If ${EESSI_DEV_PROJECT} is not defined, nothing is
 # appended
-export TGZ=$(printf "eessi-%s-software-%s-%s-%b%d.tar.gz" ${EESSI_VERSION} ${EESSI_OS_TYPE} ${EESSI_SOFTWARE_SUBDIR_OVERRIDE//\//-} ${EESSI_DEV_PROJECT:+$EESSI_DEV_PROJECT-} ${timestamp})
+export TGZ=$(printf "eessi-%s-software-%s-%s-%s-%b%d.tar.gz" ${EESSI_VERSION} ${EESSI_OS_TYPE} ${EESSI_SOFTWARE_SUBDIR_OVERRIDE//\//-} ${EESSI_ACCELERATOR_TARGET_OVERRIDE} ${EESSI_DEV_PROJECT:+$EESSI_DEV_PROJECT-} ${timestamp})
 
 # Export EESSI_DEV_PROJECT to use it (if needed) when making tarball
 echo "bot/build.sh: EESSI_DEV_PROJECT='${EESSI_DEV_PROJECT}'"

--- a/bot/build.sh
+++ b/bot/build.sh
@@ -271,7 +271,7 @@ source $software_layer_dir/init/eessi_defaults
 # append the project (subdirectory) name to the end tarball name. This is information
 # then used at the ingestion stage. If ${EESSI_DEV_PROJECT} is not defined, nothing is
 # appended
-export TGZ=$(printf "eessi-%s-software-%s-%s-%s-%b%d.tar.gz" ${EESSI_VERSION} ${EESSI_OS_TYPE} ${EESSI_SOFTWARE_SUBDIR_OVERRIDE//\//-} ${EESSI_ACCELERATOR_TARGET_OVERRIDE} ${EESSI_DEV_PROJECT:+$EESSI_DEV_PROJECT-} ${timestamp})
+export TGZ=$(printf "eessi-%s-software-%s-%s-%s-%b%d.tar.gz" ${EESSI_VERSION} ${EESSI_OS_TYPE} ${EESSI_SOFTWARE_SUBDIR_OVERRIDE//\//-} ${EESSI_ACCELERATOR_TARGET_OVERRIDE//\//-} ${EESSI_DEV_PROJECT:+$EESSI_DEV_PROJECT-} ${timestamp})
 
 # Export EESSI_DEV_PROJECT to use it (if needed) when making tarball
 echo "bot/build.sh: EESSI_DEV_PROJECT='${EESSI_DEV_PROJECT}'"

--- a/easystacks/software.eessi.io/2023.06/accel/nvidia/should_never_be_merged/eessi-2023.06-eb-5.1.1-2023a-CUDA.yml
+++ b/easystacks/software.eessi.io/2023.06/accel/nvidia/should_never_be_merged/eessi-2023.06-eb-5.1.1-2023a-CUDA.yml
@@ -1,0 +1,5 @@
+easyconfigs:
+  - CUDA-12.1.1.eb:
+      options:
+        accept-eula-for: CUDA
+  - pmt-1.2.0-GCCcore-12.3.0-CUDA-12.1.1.eb:

--- a/easystacks/software.eessi.io/2023.06/accel/nvidia/should_never_be_merged/eessi-2023.06-eb-5.1.1-2023a-CUDA.yml
+++ b/easystacks/software.eessi.io/2023.06/accel/nvidia/should_never_be_merged/eessi-2023.06-eb-5.1.1-2023a-CUDA.yml
@@ -1,5 +1,0 @@
-easyconfigs:
-  - CUDA-12.1.1.eb:
-      options:
-        accept-eula-for: CUDA
-  - pmt-1.2.0-GCCcore-12.3.0-CUDA-12.1.1.eb:


### PR DESCRIPTION
This fixes the issue reported here https://github.com/EESSI/eessi-bot-software-layer/issues/333 which didn't turn out to be a bot issue, but a naming issue: if the names (excluding timestamp) are the same, the bot will only upload the latest (if the upload policy is 'latest'). So, we need to add the GPU architecture in the name, so that if we build e.g. for `zen2`+`cc70` and `zen2` + `cc80`, that _both_ are uploaded (and not just the one that was built the latest).

Proof that this PR fixes the issue is in https://github.com/casparvl/software-layer-scripts/pull/1 , where I've first reproduced the issue (i.e. you see only one of the two tarballs being deployed). Then, with the fix implemented, I did a rebuild and redeploy, and it deployed _both_ tarballs.