### PR TITLE
Fix tarball naming for CPU-only tarballs

### DIFF
--- a/bot/build.sh
+++ b/bot/build.sh
@@ -271,7 +271,11 @@ source $software_layer_dir/init/eessi_defaults
 # append the project (subdirectory) name to the end tarball name. This is information
 # then used at the ingestion stage. If ${EESSI_DEV_PROJECT} is not defined, nothing is
 # appended
-export TGZ=$(printf "eessi-%s-software-%s-%s-%s-%b%d.tar.gz" ${EESSI_VERSION} ${EESSI_OS_TYPE} ${EESSI_SOFTWARE_SUBDIR_OVERRIDE//\//-} ${EESSI_ACCELERATOR_TARGET_OVERRIDE//\//-} ${EESSI_DEV_PROJECT:+$EESSI_DEV_PROJECT-} ${timestamp})
+if [[ -z ${EESSI_ACCELERATOR_TARGET_OVERRIDE} ]];
+    export TGZ=$(printf "eessi-%s-software-%s-%s-%b%d.tar.gz" ${EESSI_VERSION} ${EESSI_OS_TYPE} ${EESSI_SOFTWARE_SUBDIR_OVERRIDE//\//-} ${EESSI_DEV_PROJECT:+$EESSI_DEV_PROJECT-} ${timestamp})
+else
+    export TGZ=$(printf "eessi-%s-software-%s-%s-%s-%b%d.tar.gz" ${EESSI_VERSION} ${EESSI_OS_TYPE} ${EESSI_SOFTWARE_SUBDIR_OVERRIDE//\//-} ${EESSI_ACCELERATOR_TARGET_OVERRIDE//\//-} ${EESSI_DEV_PROJECT:+$EESSI_DEV_PROJECT-} ${timestamp})
+fi
 
 # Export EESSI_DEV_PROJECT to use it (if needed) when making tarball
 echo "bot/build.sh: EESSI_DEV_PROJECT='${EESSI_DEV_PROJECT}'"

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -1,5 +1,6 @@
 # Hooks to customize how EasyBuild installs software in EESSI
 # see https://docs.easybuild.io/en/latest/Hooks.html
+# DUMMY CHANGE, DONT MERGE
 import ast
 import datetime
 import glob
@@ -151,7 +152,7 @@ def parse_list_of_dicts_env(var_name):
     if not re.match(r'^[A-Za-z_][A-Za-z0-9_]*$', var_name):
         raise ValueError(f"Invalid environment variable name: {var_name}")
     list_string = os.getenv(var_name, '[]')
-    
+
     list_of_dicts = []
     try:
         # Try JSON format first
@@ -162,7 +163,7 @@ def parse_list_of_dicts_env(var_name):
             list_of_dicts = ast.literal_eval(list_string)
         except (ValueError, SyntaxError):
             raise ValueError(f"Environment variable '{var_name}' does not contain a valid list of dictionaries.")
-    
+
     return list_of_dicts
 
 
@@ -211,7 +212,7 @@ def post_ready_hook(self, *args, **kwargs):
         parallel = self.parallel
     else:
         parallel = self.cfg['parallel']
-    
+
     if parallel == 1:
         return  # no need to limit if already using 1 core
 
@@ -733,7 +734,7 @@ def pre_configure_hook_score_p(self, *args, **kwargs):
 def pre_configure_hook_vsearch(self, *args, **kwargs):
     """
     Pre-configure hook for VSEARCH
-    - Workaround for a Zlib macro being renamed in Gentoo, see https://bugs.gentoo.org/383179 
+    - Workaround for a Zlib macro being renamed in Gentoo, see https://bugs.gentoo.org/383179
       (solves "expected initializer before 'OF'" errors)
     """
     if self.name == 'VSEARCH':


### PR DESCRIPTION
When introducing the new tarball naming to make sure tarball names were unique per GPU architecture, I did not realize that `${EESSI_ACCELERATOR_TARGET_OVERRIDE//\//-}` would simply be completely empty for a CPU build, and thus the string formatting would be short on value. This caused tarball names to be incorrect, as they ended with `-0.tar.gz`, see e.g. https://github.com/EESSI/staging_bundles/pull/9 . That's problematic, since the bot assumes the item after the last `-` to be the timestamp. So, with the policy to only upload the last tarball _every_ tarball would be uploaded, since all had identical timestamp (`0`) according to the bot.

Fixed in this PR by making the number of formatting specs conditional on the accelerator override being non-empty.