### PR TITLE
fix condition in EESSI-extend so environment variable to configure EasyBuild 5.1+ are only defined when EasyBuild >= 5.1 is used

### DIFF
--- a/EESSI-extend-easybuild.eb
+++ b/EESSI-extend-easybuild.eb
@@ -211,23 +211,12 @@ end
 easybuild_version = os.getenv("EBVERSIONEASYBUILD") or easybuild_version
 eessi_version = os.getenv("EESSI_VERSION") or "2023.06"
 
-if (mode() == "unload") then
-  -- unload unconditionally, so that even if EB versions were switched in the meantime, this gets unset
-  -- This avoids issues where EESSI-extend is first loaded with EB => 5.1 (which set these vars)
-  -- but then EB is swapped for a version < 5.1 and then EESSI-extend is unloaded (which would not unset
-  -- these vars if we did it conditional on the EB version)
-  setenv ("EASYBUILD_STRICT_RPATH_SANITY_CHECK", "1")
-  setenv ("EASYBUILD_CUDA_SANITY_CHECK_ERROR_ON_FAILED_CHECKS", "1")
-  setenv ("EASYBUILD_FAIL_ON_MOD_FILES_GCCCORE", "1")
-  setenv ("EASYBUILD_LOCAL_VAR_NAMING_CHECK", "error")
-  -- This can still be conditional, eessi_version is always set
-  if convertToCanonical(eessi_version) > convertToCanonical("2023.06") then
-    setenv ("EASYBUILD_PREFER_PYTHON_SEARCH_PATH", "EBPYTHONPREFIXES")
-    setenv ("EASYBUILD_MODULE_SEARCH_PATH_HEADERS", "include_paths")
-    setenv ("EASYBUILD_SEARCH_PATH_CPP_HEADERS", "include_paths")
-  end
 -- Set environment variables that are EasyBuild version specific
-elseif convertToCanonical(easybuild_version) >= convertToCanonical("5.1") then
+-- Do unload unconditionally, so that even if EB versions were switched in the meantime, this gets unset
+-- This avoids issues where EESSI-extend is first loaded with EB => 5.1 (which set these vars)
+-- but then EB is swapped for a version < 5.1 and then EESSI-extend is unloaded (which would not unset
+-- these vars if we did it conditional on the EB version)
+if convertToCanonical(easybuild_version) >= convertToCanonical("5.1") or mode() == "unload" then
   setenv ("EASYBUILD_STRICT_RPATH_SANITY_CHECK", "1")
   setenv ("EASYBUILD_CUDA_SANITY_CHECK_ERROR_ON_FAILED_CHECKS", "1")
   setenv ("EASYBUILD_FAIL_ON_MOD_FILES_GCCCORE", "1")

--- a/EESSI-extend-easybuild.eb
+++ b/EESSI-extend-easybuild.eb
@@ -212,7 +212,7 @@ easybuild_version = os.getenv("EBVERSIONEASYBUILD") or easybuild_version
 eessi_version = os.getenv("EESSI_VERSION") or "2023.06"
 
 -- Set environment variables that are EasyBuild version specific
-if convertToCanonical(easybuild_version) > convertToCanonical("4") then
+if convertToCanonical(easybuild_version) >= convertToCanonical("5.1") then
   setenv ("EASYBUILD_STRICT_RPATH_SANITY_CHECK", "1")
   setenv ("EASYBUILD_CUDA_SANITY_CHECK_ERROR_ON_FAILED_CHECKS", "1")
   setenv ("EASYBUILD_FAIL_ON_MOD_FILES_GCCCORE", "1")

--- a/EESSI-extend-easybuild.eb
+++ b/EESSI-extend-easybuild.eb
@@ -211,8 +211,23 @@ end
 easybuild_version = os.getenv("EBVERSIONEASYBUILD") or easybuild_version
 eessi_version = os.getenv("EESSI_VERSION") or "2023.06"
 
+if (mode() == "unload") then
+  -- unload unconditionally, so that even if EB versions were switched in the meantime, this gets unset
+  -- This avoids issues where EESSI-extend is first loaded with EB => 5.1 (which set these vars)
+  -- but then EB is swapped for a version < 5.1 and then EESSI-extend is unloaded (which would not unset
+  -- these vars if we did it conditional on the EB version)
+  setenv ("EASYBUILD_STRICT_RPATH_SANITY_CHECK", "1")
+  setenv ("EASYBUILD_CUDA_SANITY_CHECK_ERROR_ON_FAILED_CHECKS", "1")
+  setenv ("EASYBUILD_FAIL_ON_MOD_FILES_GCCCORE", "1")
+  setenv ("EASYBUILD_LOCAL_VAR_NAMING_CHECK", "error")
+  -- This can still be conditional, eessi_version is always set
+  if convertToCanonical(eessi_version) > convertToCanonical("2023.06") then
+    setenv ("EASYBUILD_PREFER_PYTHON_SEARCH_PATH", "EBPYTHONPREFIXES")
+    setenv ("EASYBUILD_MODULE_SEARCH_PATH_HEADERS", "include_paths")
+    setenv ("EASYBUILD_SEARCH_PATH_CPP_HEADERS", "include_paths")
+  end
 -- Set environment variables that are EasyBuild version specific
-if convertToCanonical(easybuild_version) >= convertToCanonical("5.1") then
+elseif convertToCanonical(easybuild_version) >= convertToCanonical("5.1") then
   setenv ("EASYBUILD_STRICT_RPATH_SANITY_CHECK", "1")
   setenv ("EASYBUILD_CUDA_SANITY_CHECK_ERROR_ON_FAILED_CHECKS", "1")
   setenv ("EASYBUILD_FAIL_ON_MOD_FILES_GCCCORE", "1")

--- a/EESSI-install-software.sh
+++ b/EESSI-install-software.sh
@@ -247,29 +247,6 @@ if [ ! -f ${_lmod_sitepackage_file} ]; then
     python3 ${TOPDIR}/create_lmodsitepackage.py ${_eessi_software_path}
 fi
 
-# Install full CUDA SDK and cu* libraries in host_injections
-# (This is done *before* configuring EasyBuild as it may rely on an older EB version)
-# Hardcode this for now, see if it works
-# TODO: We should make a nice yaml and loop over all CUDA versions in that yaml to figure out what to install
-# Allow skipping CUDA SDK install in e.g. CI environments
-echo "Going to install full CUDA SDK and cu* libraries under host_injections if necessary"
-temp_install_storage=${TMPDIR}/temp_install_storage
-mkdir -p ${temp_install_storage}
-if [ -z "${skip_cuda_install}" ] || [ ! "${skip_cuda_install}" ]; then
-    ${EESSI_PREFIX}/scripts/gpu_support/nvidia/install_cuda_and_libraries.sh \
-        -t ${temp_install_storage} \
-        --accept-cuda-eula \
-        --accept-cudnn-eula
-else
-    echo "Skipping installation of CUDA SDK and cu* libraries in host_injections, since the --skip-cuda-install flag was passed"
-fi
-
-# Install NVIDIA drivers in host_injections (if they exist)
-if nvidia_gpu_available; then
-    echo "Installing NVIDIA drivers for use in prefix shell..."
-    ${EESSI_PREFIX}/scripts/gpu_support/nvidia/link_nvidia_host_libraries.sh
-fi
-
 echo ">> Configuring EasyBuild..."
 
 # Make sure EESSI-extend is not loaded, and configure location variables for a
@@ -315,6 +292,30 @@ fi
 echo "DEBUG: before loading EESSI-extend // EASYBUILD_INSTALLPATH='${EASYBUILD_INSTALLPATH}'"
 source $TOPDIR/load_eessi_extend_module.sh ${EESSI_VERSION}
 echo "DEBUG: after loading EESSI-extend //  EASYBUILD_INSTALLPATH='${EASYBUILD_INSTALLPATH}'"
+
+# Install full CUDA SDK and cu* libraries in host_injections
+# (This is done *before* configuring EasyBuild as it may rely on an older EB version)
+# Hardcode this for now, see if it works
+# TODO: We should make a nice yaml and loop over all CUDA versions in that yaml to figure out what to install
+# Allow skipping CUDA SDK install in e.g. CI environments
+echo "Going to install full CUDA SDK and cu* libraries under host_injections if necessary"
+temp_install_storage=${TMPDIR}/temp_install_storage
+mkdir -p ${temp_install_storage}
+if [ -z "${skip_cuda_install}" ] || [ ! "${skip_cuda_install}" ]; then
+    ${EESSI_PREFIX}/scripts/gpu_support/nvidia/install_cuda_and_libraries.sh \
+        -t ${temp_install_storage} \
+        --accept-cuda-eula \
+        --accept-cudnn-eula
+else
+    echo "Skipping installation of CUDA SDK and cu* libraries in host_injections, since the --skip-cuda-install flag was passed"
+fi
+
+# Install NVIDIA drivers in host_injections (if they exist)
+if nvidia_gpu_available; then
+    echo "Installing NVIDIA drivers for use in prefix shell..."
+    ${EESSI_PREFIX}/scripts/gpu_support/nvidia/link_nvidia_host_libraries.sh
+fi
+
 
 if [ ! -z "${shared_fs_path}" ]; then
     shared_eb_sourcepath=${shared_fs_path}/easybuild/sources

--- a/scripts/gpu_support/nvidia/install_cuda_and_libraries.sh
+++ b/scripts/gpu_support/nvidia/install_cuda_and_libraries.sh
@@ -115,6 +115,7 @@ for EASYSTACK_FILE in ${TOPDIR}/easystacks/eessi-*CUDA*.yml; do
     unset EESSI_PROJECT_INSTALL
     unset EESSI_USER_INSTALL
     export EESSI_SITE_INSTALL=1
+    echo "BEFORE UNLOADING EESSI-EXTEND, EASYBUILD_CUDA_SANITY_CHECK_ERROR_ON_FAILED_CHECKS = $EASYBUILD_CUDA_SANITY_CHECK_ERROR_ON_FAILED_CHECKS"
     module unload EESSI-extend
     ml_av_eessi_extend_out=${tmpdir}/ml_av_eessi_extend.out
     # need to use --ignore_cache to avoid the case that the module was removed (to be
@@ -127,7 +128,9 @@ for EASYSTACK_FILE in ${TOPDIR}/easystacks/eessi-*CUDA*.yml; do
         error="\nNo module for EESSI-extend/${EESSI_EXTEND_VERSION} found\nwhile EESSI has been initialised to use software under ${EESSI_SOFTWARE_PATH}\n"
         fatal_error "${error}"
     fi
+    echo "BEFORE RELOADING EESSI-EXTEND, EASYBUILD_CUDA_SANITY_CHECK_ERROR_ON_FAILED_CHECKS = $EASYBUILD_CUDA_SANITY_CHECK_ERROR_ON_FAILED_CHECKS"
     module --ignore_cache load EESSI-extend/${EESSI_EXTEND_VERSION}
+    echo "AFTER RELOADING EESSI-EXTEND, EASYBUILD_CUDA_SANITY_CHECK_ERROR_ON_FAILED_CHECKS = $EASYBUILD_CUDA_SANITY_CHECK_ERROR_ON_FAILED_CHECKS"
     unset EESSI_EXTEND_VERSION
 
     # If there is a GPU on the node, the installation path will by default have an

--- a/scripts/gpu_support/nvidia/install_cuda_and_libraries.sh
+++ b/scripts/gpu_support/nvidia/install_cuda_and_libraries.sh
@@ -115,7 +115,6 @@ for EASYSTACK_FILE in ${TOPDIR}/easystacks/eessi-*CUDA*.yml; do
     unset EESSI_PROJECT_INSTALL
     unset EESSI_USER_INSTALL
     export EESSI_SITE_INSTALL=1
-    echo "BEFORE UNLOADING EESSI-EXTEND, EASYBUILD_CUDA_SANITY_CHECK_ERROR_ON_FAILED_CHECKS = $EASYBUILD_CUDA_SANITY_CHECK_ERROR_ON_FAILED_CHECKS"
     module unload EESSI-extend
     ml_av_eessi_extend_out=${tmpdir}/ml_av_eessi_extend.out
     # need to use --ignore_cache to avoid the case that the module was removed (to be
@@ -128,9 +127,7 @@ for EASYSTACK_FILE in ${TOPDIR}/easystacks/eessi-*CUDA*.yml; do
         error="\nNo module for EESSI-extend/${EESSI_EXTEND_VERSION} found\nwhile EESSI has been initialised to use software under ${EESSI_SOFTWARE_PATH}\n"
         fatal_error "${error}"
     fi
-    echo "BEFORE RELOADING EESSI-EXTEND, EASYBUILD_CUDA_SANITY_CHECK_ERROR_ON_FAILED_CHECKS = $EASYBUILD_CUDA_SANITY_CHECK_ERROR_ON_FAILED_CHECKS"
     module --ignore_cache load EESSI-extend/${EESSI_EXTEND_VERSION}
-    echo "AFTER RELOADING EESSI-EXTEND, EASYBUILD_CUDA_SANITY_CHECK_ERROR_ON_FAILED_CHECKS = $EASYBUILD_CUDA_SANITY_CHECK_ERROR_ON_FAILED_CHECKS"
     unset EESSI_EXTEND_VERSION
 
     # If there is a GPU on the node, the installation path will by default have an


### PR DESCRIPTION
edit: also reverting change of when `install_cuda_and_libraries` and `link_nvidia_host_libraries.sh` are called, that was changed in #54 but wasn't correct