### PR TITLE
fix condition in EESSI-extend + fix tarball naming for CPU-only tarballs

### DIFF
--- a/bot/build.sh
+++ b/bot/build.sh
@@ -271,7 +271,7 @@ source $software_layer_dir/init/eessi_defaults
 # append the project (subdirectory) name to the end tarball name. This is information
 # then used at the ingestion stage. If ${EESSI_DEV_PROJECT} is not defined, nothing is
 # appended
-if [[ -z ${EESSI_ACCELERATOR_TARGET_OVERRIDE} ]];
+if [[ -z ${EESSI_ACCELERATOR_TARGET_OVERRIDE} ]]; then
     export TGZ=$(printf "eessi-%s-software-%s-%s-%b%d.tar.gz" ${EESSI_VERSION} ${EESSI_OS_TYPE} ${EESSI_SOFTWARE_SUBDIR_OVERRIDE//\//-} ${EESSI_DEV_PROJECT:+$EESSI_DEV_PROJECT-} ${timestamp})
 else
     export TGZ=$(printf "eessi-%s-software-%s-%s-%s-%b%d.tar.gz" ${EESSI_VERSION} ${EESSI_OS_TYPE} ${EESSI_SOFTWARE_SUBDIR_OVERRIDE//\//-} ${EESSI_ACCELERATOR_TARGET_OVERRIDE//\//-} ${EESSI_DEV_PROJECT:+$EESSI_DEV_PROJECT-} ${timestamp})

--- a/bot/build.sh
+++ b/bot/build.sh
@@ -271,7 +271,11 @@ source $software_layer_dir/init/eessi_defaults
 # append the project (subdirectory) name to the end tarball name. This is information
 # then used at the ingestion stage. If ${EESSI_DEV_PROJECT} is not defined, nothing is
 # appended
-export TGZ=$(printf "eessi-%s-software-%s-%s-%s-%b%d.tar.gz" ${EESSI_VERSION} ${EESSI_OS_TYPE} ${EESSI_SOFTWARE_SUBDIR_OVERRIDE//\//-} ${EESSI_ACCELERATOR_TARGET_OVERRIDE//\//-} ${EESSI_DEV_PROJECT:+$EESSI_DEV_PROJECT-} ${timestamp})
+if [[ -z ${EESSI_ACCELERATOR_TARGET_OVERRIDE} ]];
+    export TGZ=$(printf "eessi-%s-software-%s-%s-%b%d.tar.gz" ${EESSI_VERSION} ${EESSI_OS_TYPE} ${EESSI_SOFTWARE_SUBDIR_OVERRIDE//\//-} ${EESSI_DEV_PROJECT:+$EESSI_DEV_PROJECT-} ${timestamp})
+else
+    export TGZ=$(printf "eessi-%s-software-%s-%s-%s-%b%d.tar.gz" ${EESSI_VERSION} ${EESSI_OS_TYPE} ${EESSI_SOFTWARE_SUBDIR_OVERRIDE//\//-} ${EESSI_ACCELERATOR_TARGET_OVERRIDE//\//-} ${EESSI_DEV_PROJECT:+$EESSI_DEV_PROJECT-} ${timestamp})
+fi
 
 # Export EESSI_DEV_PROJECT to use it (if needed) when making tarball
 echo "bot/build.sh: EESSI_DEV_PROJECT='${EESSI_DEV_PROJECT}'"

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -1,6 +1,5 @@
 # Hooks to customize how EasyBuild installs software in EESSI
 # see https://docs.easybuild.io/en/latest/Hooks.html
-# DUMMY CHANGE, DONT MERGE
 import ast
 import datetime
 import glob
@@ -152,7 +151,7 @@ def parse_list_of_dicts_env(var_name):
     if not re.match(r'^[A-Za-z_][A-Za-z0-9_]*$', var_name):
         raise ValueError(f"Invalid environment variable name: {var_name}")
     list_string = os.getenv(var_name, '[]')
-
+    
     list_of_dicts = []
     try:
         # Try JSON format first
@@ -163,7 +162,7 @@ def parse_list_of_dicts_env(var_name):
             list_of_dicts = ast.literal_eval(list_string)
         except (ValueError, SyntaxError):
             raise ValueError(f"Environment variable '{var_name}' does not contain a valid list of dictionaries.")
-
+    
     return list_of_dicts
 
 
@@ -212,7 +211,7 @@ def post_ready_hook(self, *args, **kwargs):
         parallel = self.parallel
     else:
         parallel = self.cfg['parallel']
-
+    
     if parallel == 1:
         return  # no need to limit if already using 1 core
 
@@ -734,7 +733,7 @@ def pre_configure_hook_score_p(self, *args, **kwargs):
 def pre_configure_hook_vsearch(self, *args, **kwargs):
     """
     Pre-configure hook for VSEARCH
-    - Workaround for a Zlib macro being renamed in Gentoo, see https://bugs.gentoo.org/383179
+    - Workaround for a Zlib macro being renamed in Gentoo, see https://bugs.gentoo.org/383179 
       (solves "expected initializer before 'OF'" errors)
     """
     if self.name == 'VSEARCH':

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -1,5 +1,6 @@
 # Hooks to customize how EasyBuild installs software in EESSI
 # see https://docs.easybuild.io/en/latest/Hooks.html
+# DUMMY CHANGE, DONT MERGE
 import ast
 import datetime
 import glob
@@ -151,7 +152,7 @@ def parse_list_of_dicts_env(var_name):
     if not re.match(r'^[A-Za-z_][A-Za-z0-9_]*$', var_name):
         raise ValueError(f"Invalid environment variable name: {var_name}")
     list_string = os.getenv(var_name, '[]')
-    
+
     list_of_dicts = []
     try:
         # Try JSON format first
@@ -162,7 +163,7 @@ def parse_list_of_dicts_env(var_name):
             list_of_dicts = ast.literal_eval(list_string)
         except (ValueError, SyntaxError):
             raise ValueError(f"Environment variable '{var_name}' does not contain a valid list of dictionaries.")
-    
+
     return list_of_dicts
 
 
@@ -211,7 +212,7 @@ def post_ready_hook(self, *args, **kwargs):
         parallel = self.parallel
     else:
         parallel = self.cfg['parallel']
-    
+
     if parallel == 1:
         return  # no need to limit if already using 1 core
 
@@ -733,7 +734,7 @@ def pre_configure_hook_score_p(self, *args, **kwargs):
 def pre_configure_hook_vsearch(self, *args, **kwargs):
     """
     Pre-configure hook for VSEARCH
-    - Workaround for a Zlib macro being renamed in Gentoo, see https://bugs.gentoo.org/383179 
+    - Workaround for a Zlib macro being renamed in Gentoo, see https://bugs.gentoo.org/383179
       (solves "expected initializer before 'OF'" errors)
     """
     if self.name == 'VSEARCH':


### PR DESCRIPTION
This combines the fixes included in two existing PRs by @casparvl (after discussing this with him):
- #65 
- #66

In addition, the dummy changes made to `eb_hooks.py` were undone by reverting commit f85e74ef05570803d49f7255093ec11b4f0a0f9f.

We need to trigger a build of new tarballs for #66 since without the fix from #65 we would pick up multiple tarballs for a single CPU target (potentially deploying incorrect `EESSI-extend` modules).