### PR TITLE
Update one more dir to reflect the new location of CUDA installations in host_injections

### DIFF
--- a/EESSI-install-software.sh
+++ b/EESSI-install-software.sh
@@ -348,7 +348,7 @@ fi
 
 # if an accelerator target is specified, we need to make sure that the CPU-only modules are also still available
 if [ ! -z ${EESSI_ACCELERATOR_TARGET} ]; then
-    CPU_ONLY_MODULES_PATH=$(echo $EASYBUILD_INSTALLPATH | sed "s@/accel/${EESSI_ACCELERATOR_TARGET}@@g")/modules/all
+    CPU_ONLY_MODULES_PATH=$(echo $EASYBUILD_INSTALLPATH | sed "s@/${EESSI_ACCELERATOR_TARGET}@@g")/modules/all
     if [ -d ${CPU_ONLY_MODULES_PATH} ]; then
         module use ${CPU_ONLY_MODULES_PATH}
     else
@@ -439,7 +439,7 @@ lmod_rc_file="$LMOD_CONFIG_DIR/lmodrc.lua"
 echo "DEBUG: lmod_rc_file='${lmod_rc_file}'"
 if [[ ! -z ${EESSI_ACCELERATOR_TARGET} ]]; then
     # EESSI_ACCELERATOR_TARGET is set, so let's remove the accelerator path from $lmod_rc_file
-    lmod_rc_file=$(echo ${lmod_rc_file} | sed "s@/accel/${EESSI_ACCELERATOR_TARGET}@@")
+    lmod_rc_file=$(echo ${lmod_rc_file} | sed "s@/${EESSI_ACCELERATOR_TARGET}@@")
     echo "Path to lmodrc.lua changed to '${lmod_rc_file}'"
 fi
 lmodrc_changed=$(cat ${pr_diff} | grep '^+++' | cut -f2 -d' ' | sed 's@^[a-z]/@@g' | grep '^create_lmodrc.py$' > /dev/null; echo $?)
@@ -452,7 +452,7 @@ fi
 lmod_sitepackage_file="$LMOD_PACKAGE_PATH/SitePackage.lua"
 if [[ ! -z ${EESSI_ACCELERATOR_TARGET} ]]; then
     # EESSI_ACCELERATOR_TARGET is set, so let's remove the accelerator path from $lmod_sitepackage_file
-    lmod_sitepackage_file=$(echo ${lmod_sitepackage_file} | sed "s@/accel/${EESSI_ACCELERATOR_TARGET}@@")
+    lmod_sitepackage_file=$(echo ${lmod_sitepackage_file} | sed "s@/${EESSI_ACCELERATOR_TARGET}@@")
     echo "Path to SitePackage.lua changed to '${lmod_sitepackage_file}'"
 fi
 sitepackage_changed=$(cat ${pr_diff} | grep '^+++' | cut -f2 -d' ' | sed 's@^[a-z]/@@g' | grep '^create_lmodsitepackage.py$' > /dev/null; echo $?)

--- a/scripts/gpu_support/nvidia/install_cuda_and_libraries.sh
+++ b/scripts/gpu_support/nvidia/install_cuda_and_libraries.sh
@@ -211,10 +211,14 @@ for EASYSTACK_FILE in ${TOPDIR}/easystacks/eessi-*CUDA*.yml; do
       required_space_in_tmpdir=$((required_space_in_tmpdir + ${base_storage_space}))
     fi
     
+    # Checking disk space on a non-existing folder returns a permission denied, but the error then seems to 
+    # incorrectly suggest there is insufficient disk space. Let's make sure this directory exists.
+    mkdir -p ${EASYBUILD_INSTALLPATH}
+
     # The install is pretty fat, you need lots of space for download/unpack/install
     # (~3*${base_storage_space}*1000 Bytes),
     # need to do a space check before we proceed
-    avail_space=$(df --output=avail "${EESSI_SITE_SOFTWARE_PATH}"/ | tail -n 1 | awk '{print $1}')
+    avail_space=$(df --output=avail "${EASYBUILD_INSTALLPATH}"/ | tail -n 1 | awk '{print $1}')
     min_disk_storage=$((3 * ${base_storage_space}))
     if (( avail_space < ${min_disk_storage} )); then
       fatal_error "Need at least $(echo "${min_disk_storage} / 1000000" | bc) GB disk space to install CUDA and other libraries under ${EESSI_SITE_SOFTWARE_PATH}, exiting now..."


### PR DESCRIPTION
Let's make sure the EASYBUILD_INSTALLPATH is used for the disk space check, since the installpath changed in https://github.com/EESSI/software-layer-scripts/pull/59 and now it was doing the disk space check on a different folder than the installation prefix.

 Also, make sure the install prefix exists to avoid strange errors that say you're out of disk space, while actually, the dir just didn't exist