### PR TITLE
Fix host injection path that was still pointing to .../versions/... instead of .../host_injections/...

### DIFF
--- a/create_lmodsitepackage.py
+++ b/create_lmodsitepackage.py
@@ -132,7 +132,8 @@ local function eessi_cuda_and_libraries_enabled_load_hook(t)
         -- get the host_injections path, and add only the EESSI_CPU_FAMILY at the end
         local strip_suffix = os.getenv('EESSI_VERSION') .. "/software/" .. os.getenv('EESSI_OS_TYPE') .. "/"
         strip_suffix = strip_suffix .. os.getenv('EESSI_SOFTWARE_SUBDIR')
-        local hostInjections = string.gsub(os.getenv('EESSI_SOFTWARE_PATH') or "", strip_suffix, os.getenv('EESSI_CPU_FAMILY'))
+        local hostInjections = string.gsub(os.getenv('EESSI_SOFTWARE_PATH') or "", 'versions', 'host_injections')
+        hostInjections = string.gsub(hostInjections, strip_suffix, os.getenv('EESSI_CPU_FAMILY'))
 
         -- build final path where the software should be installed
         local packageEasyBuildDir = hostInjections .. "/software/" .. t.modFullName .. "/easybuild"


### PR DESCRIPTION
I was getting:

```
$ module load CUDA/12.1.1
Lmod has detected the following error:
You requested to load CUDA  but while the module file exists, the actual software is not entirely shipped with EESSI due to licencing. You will need to install a full copy of the CUDA package where EESSI can find it.
For more information on how to do this, see https://www.eessi.io/docs/site_specific_config/gpu/.

While processing the following module(s):
    Module fullname  Module Filename
    ---------------  ---------------
    CUDA/12.1.1      /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen4/accel/nvidia/cc90/modules/all/CUDA/12.1.1.lua
```

Even though the CUDA toolkit was installed in the expected location (i.e. `/cvmfs/software.eessi.io/host_injections/x86_64/software/CUDA`). Turns out we didn't construct the `hostInjections` variable correctly. As a result, the `packageEasyBuildDir` variable was `/cvmfs/software.eessi.io/versions/x86_64/software/CUDA/12.4.0/easybuild`, which is clearly wrong. It should have pointed to `.../host_injections/...`

