### PR TITLE
Avoid error when unloading EasyBuild module

### DIFF
--- a/EESSI-extend-easybuild.eb
+++ b/EESSI-extend-easybuild.eb
@@ -216,7 +216,7 @@ eessi_version = os.getenv("EESSI_VERSION") or "2023.06"
 -- This avoids issues where EESSI-extend is first loaded with EB => 5.1 (which set these vars)
 -- but then EB is swapped for a version < 5.1 and then EESSI-extend is unloaded (which would not unset
 -- these vars if we did it conditional on the EB version)
-if convertToCanonical(easybuild_version) >= convertToCanonical("5.1") or mode() == "unload" then
+if mode() == "unload" or mode() == "dependencyCk" or convertToCanonical(easybuild_version) >= convertToCanonical("5.1") then
   setenv ("EASYBUILD_STRICT_RPATH_SANITY_CHECK", "1")
   setenv ("EASYBUILD_CUDA_SANITY_CHECK_ERROR_ON_FAILED_CHECKS", "1")
   setenv ("EASYBUILD_FAIL_ON_MOD_FILES_GCCCORE", "1")


### PR DESCRIPTION
When unloading EasyBuild with the extend-Module loaded it fails with: Lmod has detected the following error: Unable to load module because of error when evaluating modulefile:
     /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/amd/zen4/modules/all/EESSI-extend/2023.06-easybuild.lua: [string "help([==[..."]:239: attempt to compare string with nil

This is due to the easybuild_version being not set.

Change the order of the mode check and include the dependency check type which I discovered being used with manual printf debugging


The error also happens during the sanity check step when installing EasyBuild