### PR TITLE
Reload EESSI-extend when switching to a different EasyBuild version

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-system.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-system.yml
@@ -1,4 +1,0 @@
-easyconfigs:
-  - cowsay-3.04.eb:
-      options:
-        from-commit: 2b8a316e7e61cb69597ba119528a714e9495edac

--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-system.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-4.9.4-system.yml
@@ -1,0 +1,4 @@
+easyconfigs:
+  - cowsay-3.04.eb:
+      options:
+        from-commit: 2b8a316e7e61cb69597ba119528a714e9495edac

--- a/load_easybuild_module.sh
+++ b/load_easybuild_module.sh
@@ -111,6 +111,10 @@ fi
 
 echo ">> Loading EasyBuild v${EB_VERSION} module..."
 module ${IGNORE_CACHE} load EasyBuild/${EB_VERSION}
+# EESSI-extend checks for the EB version being used.
+# If EESSI-extend is already loaded, we need to reload it in order to reevaluate the checks and reconfigure EasyBuild.
+module is-loaded EESSI-extend && module update
+
 eb_show_system_info_out=${TMPDIR}/eb_show_system_info.out
 ${EB} --show-system-info > ${eb_show_system_info_out}
 if [[ $? -eq 0 ]]; then
@@ -127,9 +131,5 @@ else
     cat ${eb_show_system_info_out}
     fatal_error "EasyBuild not working?!"
 fi
-
-# EESSI-extend checks for the EB version being used.
-# If EESSI-extend is already loaded, we need to reload it in order to reevaluate the checks.
-module is-loaded EESSI-extend && module update
 
 unset EB_VERSION

--- a/load_easybuild_module.sh
+++ b/load_easybuild_module.sh
@@ -113,7 +113,7 @@ echo ">> Loading EasyBuild v${EB_VERSION} module..."
 module ${IGNORE_CACHE} load EasyBuild/${EB_VERSION}
 # EESSI-extend checks for the EB version being used.
 # If EESSI-extend is already loaded, we need to reload it in order to reevaluate the checks and reconfigure EasyBuild.
-module is-loaded EESSI-extend && module update
+module is-loaded EESSI-extend && module load EESSI-extend
 
 eb_show_system_info_out=${TMPDIR}/eb_show_system_info.out
 ${EB} --show-system-info > ${eb_show_system_info_out}

--- a/load_easybuild_module.sh
+++ b/load_easybuild_module.sh
@@ -128,4 +128,8 @@ else
     fatal_error "EasyBuild not working?!"
 fi
 
+# EESSI-extend checks for the EB version being used.
+# If EESSI-extend is already loaded, we need to reload it in order to reevaluate the checks.
+module is-loaded EESSI-extend && module update
+
 unset EB_VERSION


### PR DESCRIPTION
When loading EESSI-extend, it will automatically load the latest EB version. The EESSI-extend module does some EB version checks, and based on the version it may set certain EB env vars. If you then switch to an older EB version, these checks are not reevaluated, which may lead to a broken EB setup and errors like:
```
The following have been reloaded with a version change:
  1) EasyBuild/5.1.1 => EasyBuild/4.9.4

ERROR: Failed to parse configuration options: 'Found 3 environment variable(s) that are prefixed with EASYBUILD but do not match valid option(s): EASYBUILD_CUDA_SANITY_CHECK_ERROR_ON_FAILED_CHECKS,EASYBUILD_FAIL_ON_MOD_FILES_GCCCORE,EASYBUILD_STRICT_RPATH_SANITY_CHECK'
ESC[31mERROR: EasyBuild not working?!ESC[0m
```

This does not contain a fix yet, I first want to reproduce the issue with a simple example.