### PR TITLE
cmake hook to use ncurses library from EESSI

### DIFF
--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -942,6 +942,19 @@ def pre_configure_hook_LAMMPS_zen4(self, *args, **kwargs):
     else:
         raise EasyBuildError("LAMMPS-specific hook triggered for non-LAMMPS easyconfig?!")
 
+def pre_configure_hook_cmake_system(self, *args, **kwargs):
+    """
+    pre-configure hook for cmake built with SYSTEM toolchain:
+    - unset configopts for cmake easyconfigs using the SYSTEM toolchain
+    - https://github.com/EESSI/software-layer/issues/1175
+    """
+
+    if self.name == 'CMake':
+        if self.toolchain.name == 'system':
+            print_msg("Unset configopts to use ncurses library from the EESSI compatibility layer")
+            self.cfg['configopts'] = ''
+    else:
+        raise EasyBuildError("CMake-specific hook triggered for non-CMake easyconfig?!")
 
 def pre_test_hook(self, *args, **kwargs):
     """Main pre-test hook: trigger custom functions based on software name."""
@@ -1484,6 +1497,7 @@ PRE_CONFIGURE_HOOKS = {
     'LAMMPS': pre_configure_hook_LAMMPS_zen4,
     'Score-P': pre_configure_hook_score_p,
     'VSEARCH': pre_configure_hook_vsearch,
+    'CMake': pre_configure_hook_cmake_system,
 }
 
 PRE_TEST_HOOKS = {


### PR DESCRIPTION
this hook fixes issue https://github.com/EESSI/software-layer/issues/1175

now I can build cmake on top of EESSI but I noticed something weird. I don't know why `configopts` are not completely removed. This is the original easyconfig:

```
configopts = "-- "
configopts += "-DCURSES_CURSES_LIBRARY=$EBROOTNCURSES/lib/libcurses.a "
configopts += "-DCURSES_FORM_LIBRARY=$EBROOTNCURSES/lib/libform.a "
configopts += "-DCURSES_NCURSES_LIBRARY=$EBROOTNCURSES/lib/libncurses.a "
```

but when building with this hook I see this (notice the `--` after `--parallel=16`

```
  >> running shell command:
        ./configure --prefix=/scicore/home/scicore/escobar/eessi/versions/2023.06/software/linux/x86_64/amd/zen2/software/CMake/3.18.4  --parallel=16 --verbose --  -DCMAKE_USE_OPENSSL=ON
```

I am also not sure if I should use `print_msg()` or something different like `log.info` or `log.debug` 