### PR TITLE
check EB version when checking if `terse` build option is used

### DIFF
--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -68,6 +68,7 @@ EESSI_SUPPORTED_TOP_LEVEL_TOOLCHAINS = {
 
 
 # Ensure that we don't print any messages in --terse mode
+# Note that --terse was introduced in EB 4.9.1
 orig_print_msg = print_msg
 orig_print_warning = print_warning
 

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -72,12 +72,12 @@ orig_print_msg = print_msg
 orig_print_warning = print_warning
 
 def print_msg(*args, **kwargs):
-    if not build_option('terse'):
+    if EASYBUILD_VERSION < '4.9.1' or not build_option('terse'):
         orig_print_msg(*args, **kwargs)
 
-    
+
 def print_warning(*args, **kwargs):
-    if not build_option('terse'):
+    if EASYBUILD_VERSION < '4.9.1' or not build_option('terse'):
         orig_print_warning(*args, **kwargs)
 
 


### PR DESCRIPTION
The `terse` build option was introduced in EB 4.9.1, and builds with older EB versions now fail with (see https://github.com/EESSI/software-layer/pull/1177#issuecomment-3325400399):
```
    if not build_option('terse'):
           ^^^^^^^^^^^^^^^^^^^^^
  File "/cvmfs/software.eessi.io/versions/2023.06/software/linux/aarch64/a64fx/software/EasyBuild/4.8.2/lib/python3.11/site-packages/easybuild/tools/config.py", line 621, in build_option
    raise EasyBuildError(error_msg)
easybuild.tools.build_log.EasyBuildError: "Undefined build option: 'terse'. Make sure you have set up the EasyBuild configuration using set_up_configuration() (from easybuild.tools.options) in case you're not using EasyBuild via the 'eb' CLI."
```

