### PR TITLE
add generic hooks for unsupported modules

### DIFF
--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -50,6 +50,7 @@ EESSI_INSTALLATION_REGEX = r"^/cvmfs/[^/]*.eessi.io/versions/"
 HOST_INJECTIONS_LOCATION = "/cvmfs/software.eessi.io/host_injections/"
 
 # Make sure a single environment variable name is used for this throughout the hooks
+EESSI_IGNORE_A64FX_RUST1650_ENVVAR="EESSI_IGNORE_LMOD_ERROR_A64FX_RUST1650"
 EESSI_IGNORE_ZEN4_GCC1220_ENVVAR="EESSI_IGNORE_LMOD_ERROR_ZEN4_GCC1220"
 
 STACK_REPROD_SUBDIR = 'reprod'
@@ -458,7 +459,14 @@ def parse_hook_bump_rust_version_in_2022b_for_a64fx(ec, eprefix):
     because version 1.65.0 has build issues.
     """
     cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
+
     if cpu_target == CPU_TARGET_A64FX:
+        # For Rust 1.65.0 itself we inject an error message in the module file
+        if ec['name'] == 'Rust' and ec['version'] == '1.65.0':
+            errmsg = "Rust 1.65.0 is not supported on A64FX. Please use version 1.75.0 instead."
+            ec['modluafooter'] = 'if (not os.getenv("%s")) then LmodError("%s") end' % (EESSI_IGNORE_A64FX_RUST1650_ENVVAR, errmsg)
+
+        # For any builds that have a build dependency on Rust 1.65.0, we bump the version to 1.75.0
         if is_gcccore_1220_based(ecname=ec['name'], ecversion=ec['version'],
                                 tcname=ec['toolchain']['name'], tcversion=ec['toolchain']['version']):
 
@@ -554,9 +562,7 @@ def pre_fetch_hook(self, *args, **kwargs):
         PRE_FETCH_HOOKS[ec.name](self, *args, **kwargs)
 
     # Always trigger this one, regardless of self.name
-    cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
-    if cpu_target == CPU_TARGET_ZEN4:
-        pre_fetch_hook_zen4_gcccore1220(self, *args, **kwargs)
+    pre_fetch_hook_unsupported_modules(self, *args, **kwargs)
 
     # Always check the software installation path
     pre_fetch_hook_check_installation_path(self, *args, **kwargs)
@@ -590,13 +596,28 @@ def pre_fetch_hook_check_installation_path(self, *args, **kwargs):
                     )
 
 
-def pre_fetch_hook_zen4_gcccore1220(self, *args, **kwargs):
-    """Use --force --module-only if building a foss-2022b-based EasyConfig for Zen4.
-    This toolchain will not be supported on Zen4, so we will generate a modulefile
-    and have it print an LmodError.
+def is_unsupported_module(ec):
     """
-    if is_gcccore_1220_based(ecname=self.name, ecversion=self.version, tcname=self.toolchain.name,
-                             tcversion=self.toolchain.version):
+    Determine if the given module is unsupported in EESSI, and hence if a dummy module needs to be built that just prints an LmodError.
+    If true, this function returns the name of the environment variable that can be used to ignore that particular LmodError,
+    as this is still required to actually build the module itself (EasyBuild will load/test the module).
+    Otherwise, it returns False.
+    """
+    cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
+
+    if cpu_target == CPU_TARGET_A64FX and ec.name == 'Rust' and ec.version == '1.65.0':
+        return EESSI_IGNORE_A64FX_RUST1650_ENVVAR
+    if cpu_target == CPU_TARGET_ZEN4 and is_gcccore_1220_based(ecname=ec.name, ecversion=ec.version, tcname=ec.toolchain.name, tcversion=ec.toolchain.version):
+        return EESSI_IGNORE_ZEN4_GCC1220_ENVVAR
+    return False
+
+
+def pre_fetch_hook_unsupported_modules(self, *args, **kwargs):
+    """Use --force --module-only if building a module for unsupported software,
+    e.g. foss-2022b-based EasyConfigs for Zen4.
+    We will generate a modulefile and have it print an LmodError.
+    """
+    if is_unsupported_module(self):
         if hasattr(self, EESSI_MODULE_ONLY_ATTR):
             raise EasyBuildError("'self' already has attribute %s! Can't use pre_fetch hook.",
                                  EESSI_MODULE_ONLY_ATTR)
@@ -612,39 +633,37 @@ def pre_fetch_hook_zen4_gcccore1220(self, *args, **kwargs):
         print_msg("Updated build option 'force' to 'True'")
 
 
-def pre_module_hook_zen4_gcccore1220(self, *args, **kwargs):
+def pre_module_hook_unsupported_module(self, *args, **kwargs):
     """Make module load-able during module step"""
-    if is_gcccore_1220_based(ecname=self.name, ecversion=self.version, tcname=self.toolchain.name,
-                             tcversion=self.toolchain.version):
-        if hasattr(self, 'initial_environ'):
-            # Allow the module to be loaded in the module step (which uses initial environment)
-            print_msg(f"Setting {EESSI_IGNORE_ZEN4_GCC1220_ENVVAR} in initial environment")
-            self.initial_environ[EESSI_IGNORE_ZEN4_GCC1220_ENVVAR] = "1"
+    ignore_lmoderror_envvar = is_unsupported_module(self)
+    if ignore_lmoderror_envvar and hasattr(self, 'initial_environ'):
+        # Allow the module to be loaded in the module step (which uses initial environment)
+        print_msg(f"Setting {ignore_lmoderror_envvar} in initial environment")
+        self.initial_environ[ignore_lmoderror_envvar] = "1"
 
 
-def post_module_hook_zen4_gcccore1220(self, *args, **kwargs):
-    """Revert changes from pre_fetch_hook_zen4_gcccore1220"""
-    if is_gcccore_1220_based(ecname=self.name, ecversion=self.version, tcname=self.toolchain.name,
-                             tcversion=self.toolchain.version):
-        if hasattr(self, EESSI_MODULE_ONLY_ATTR):
-            update_build_option('module_only', getattr(self, EESSI_MODULE_ONLY_ATTR))
-            print_msg("Restored original build option 'module_only' to %s" % getattr(self, EESSI_MODULE_ONLY_ATTR))
-        else:
-            raise EasyBuildError("Cannot restore module_only to it's original value: 'self' is missing attribute %s.",
-                                 EESSI_MODULE_ONLY_ATTR)
+def post_module_hook_unsupported_module(self, *args, **kwargs):
+    """Revert changes from pre_fetch_hook_unsupported_modules"""
+    ignore_lmoderror_envvar = is_unsupported_module(self)
+    if hasattr(self, EESSI_MODULE_ONLY_ATTR):
+        update_build_option('module_only', getattr(self, EESSI_MODULE_ONLY_ATTR))
+        print_msg("Restored original build option 'module_only' to %s" % getattr(self, EESSI_MODULE_ONLY_ATTR))
+    else:
+        raise EasyBuildError("Cannot restore module_only to it's original value: 'self' is missing attribute %s.",
+                             EESSI_MODULE_ONLY_ATTR)
 
-        if hasattr(self, EESSI_FORCE_ATTR):
-            update_build_option('force', getattr(self, EESSI_FORCE_ATTR))
-            print_msg("Restored original build option 'force' to %s" % getattr(self, EESSI_FORCE_ATTR))
-        else:
-            raise EasyBuildError("Cannot restore force to it's original value: 'self' is misisng attribute %s.",
-                                 EESSI_FORCE_ATTR)
+    if hasattr(self, EESSI_FORCE_ATTR):
+        update_build_option('force', getattr(self, EESSI_FORCE_ATTR))
+        print_msg("Restored original build option 'force' to %s" % getattr(self, EESSI_FORCE_ATTR))
+    else:
+        raise EasyBuildError("Cannot restore force to it's original value: 'self' is misisng attribute %s.",
+                             EESSI_FORCE_ATTR)
 
-        # If the variable to allow loading is set, remove it
-        if hasattr(self, 'initial_environ'):
-            if self.initial_environ.get(EESSI_IGNORE_ZEN4_GCC1220_ENVVAR, False):
-                print_msg(f"Removing {EESSI_IGNORE_ZEN4_GCC1220_ENVVAR} in initial environment")
-                del self.initial_environ[EESSI_IGNORE_ZEN4_GCC1220_ENVVAR]
+    # If the variable to allow loading is set, remove it
+    if ignore_lmoderror_envvar and hasattr(self, 'initial_environ'):
+        if self.initial_environ.get(ignore_lmoderror_envvar, False):
+            print_msg(f"Removing {ignore_lmoderror_envvar} in initial environment")
+            del self.initial_environ[ignore_lmoderror_envvar]
 
 
 def post_easyblock_hook_copy_easybuild_subdir(self, *args, **kwargs):
@@ -1507,9 +1526,8 @@ def pre_module_hook(self, *args, **kwargs):
         PRE_MODULE_HOOKS[self.name](self, *args, **kwargs)
 
     # Always trigger this one, regardless of self.name
-    cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
-    if cpu_target == CPU_TARGET_ZEN4:
-        pre_module_hook_zen4_gcccore1220(self, *args, **kwargs)
+    if is_unsupported_module(self):
+        pre_module_hook_unsupported_module(self, *args, **kwargs)
 
 
 def post_module_hook(self, *args, **kwargs):
@@ -1518,9 +1536,8 @@ def post_module_hook(self, *args, **kwargs):
         POST_MODULE_HOOKS[self.name](self, *args, **kwargs)
 
     # Always trigger this one, regardless of self.name
-    cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
-    if cpu_target == CPU_TARGET_ZEN4:
-        post_module_hook_zen4_gcccore1220(self, *args, **kwargs)
+    if is_unsupported_module(self):
+        post_module_hook_unsupported_module(self, *args, **kwargs)
 
 
 # The post_easyblock_hook was introduced in EasyBuild 5.1.1.


### PR DESCRIPTION
This makes the existing zen4 pre_fetch / pre_module / post_module hooks a bit more generic, so that they can also be used for adding dummy modulefiles for other unsupported modules. The function `is_unsupported_module` is used to determine if something is unsupported, and if so, which environment variable can be used to ignore the LmodError of that module.

The hooks are also applied to make a module file with an LmodError for Rust 1.65.0 on A64FX.

Tested locally by building Rust 1.65.0 for A64FX with EESSI-extend:

```
$ eb Rust-1.65.0-GCCcore-12.2.0.eb
== Temporary log file in case of crash /tmp/eb-c40k2fnp/easybuild-5vbxdeyd.log
...
== processing EasyBuild easyconfig /home/bob/easybuild/easybuild-easyconfigs/easybuild/easyconfigs/r/Rust/Rust-1.65.0-GCCcore-12.2.0.eb
== building and installing Rust/1.65.0-GCCcore-12.2.0...
  >> installation prefix: /home/bob/eessi/versions/2023.06/software/linux/aarch64/a64fx/software/Rust/1.65.0-GCCcore-12.2.0
== fetching files and verifying checksums...
== Running pre-fetch hook...
== Updated build option 'module-only' to 'True'
== Updated build option 'force' to 'True'
  >> sources:
  >> /data/eb/sources/r/Rust/rustc-1.65.0-src.tar.gz [SHA256: 5828bb67f677eabf8c384020582b0ce7af884e1c84389484f7f8d00dd82c0038]
  >> patches:
  >> /home/bob/easybuild/easybuild-easyconfigs/easybuild/easyconfigs/r/Rust/Rust-1.60_sysroot-fix-interpreter.patch [SHA256: b59ed4c2591fc9098277299be21dd6752654f6f193d8652b7d21cb0fa0dd8716]
== ... (took < 1 sec)
== creating build dir, resetting environment...
  >> build dir: /data/eb/build/Rust/1.65.0/GCCcore-12.2.0
== Running post-ready hook...

WARNING: Deprecated functionality, will no longer work in EasyBuild v6.0: Easyconfig parameter 'parallel' is deprecated, use 'max_parallel' or the parallel property instead.; see https://docs.easybuild.io/deprecated-functionality/ for more 
information


WARNING: Deprecated functionality, will no longer work in EasyBuild v6.0: Easyconfig parameter 'parallel' is deprecated, use 'max_parallel' or the parallel property instead.; see https://docs.easybuild.io/deprecated-functionality/ for more 
information

== limiting parallelism to 2 (was 6, derived parallelism 8) for Rust on aarch64/a64fx 
== ... (took < 1 sec)
== unpacking [skipped]
== patching [skipped]
== preparing...
== Running pre-prepare hook...
  >> loading toolchain module: GCCcore/12.2.0
  >> loading modules for build dependencies:
  >>  * CMake/3.24.3-GCCcore-12.2.0
  >>  * Python/3.10.8-GCCcore-12.2.0-bare
  >>  * pkgconf/1.9.3-GCCcore-12.2.0
  >> loading modules for (runtime) dependencies:
  >>  * OpenSSL/1.1
  >> defining build environment for GCCcore/12.2.0 toolchain
== Running post-prepare hook...
== ... (took 1 secs)
== configuring [skipped]
== building [skipped]
== testing [skipped]
== installing [skipped]
== taking care of extensions [skipped]
== restore after iterating...
== ... (took < 1 sec)
== postprocessing [skipped]
== sanity checking [skipped]
== cleaning up [skipped]
== creating module...
== Running pre-module hook...
== Setting EESSI_IGNORE_LMOD_ERROR_A64FX_RUST1650 in initial environment
  >> generating module file @ /home/bob/eessi/versions/2023.06/software/linux/aarch64/a64fx/modules/all/Rust/1.65.0-GCCcore-12.2.0.lua
== Running post-module hook...
== Restored original build option 'module_only' to False
== Restored original build option 'force' to False
== Removing EESSI_IGNORE_LMOD_ERROR_A64FX_RUST1650 in initial environment
== ... (took < 1 sec)
== permissions...
== ... (took < 1 sec)
== packaging...
== ... (took < 1 sec)
  >> running shell command:
        bzip2 /home/bob/eessi/versions/2023.06/software/linux/aarch64/a64fx/software/Rust/1.65.0-GCCcore-12.2.0/easybuild/easybuild-Rust-1.65.0-20250925.133516.log
        [started at: 2025-09-25 13:35:16]
        [working dir: /home/bob/gits/EESSI/software-layer-scripts]
        [output and state saved to /tmp/eb-c40k2fnp/run-shell-cmd-output/bzip2-7wc0hadt]
  >> command completed: exit 0, ran in < 1s
== COMPLETED: Installation ended successfully (took 3 secs)
== Results of the build can be found in the log file(s) /home/bob/eessi/versions/2023.06/software/linux/aarch64/a64fx/software/Rust/1.65.0-GCCcore-12.2.0/easybuild/easybuild-Rust-1.65.0-20250925.133516.log.bz2
== Running post-easyblock hook...

== Build succeeded for 1 out of 1
== Summary:
   * [SUCCESS] Rust/1.65.0-GCCcore-12.2.0
== Temporary log file(s) /tmp/eb-c40k2fnp/easybuild-5vbxdeyd.log* have been removed.
== Temporary directory /tmp/eb-c40k2fnp has been removed.


$ tail -n2 ~/eessi/versions/2023.06/software/linux/aarch64/a64fx/modules/all/Rust/1.65.0-GCCcore-12.2.0.lua 
-- Built with EasyBuild version 5.1.1
if (not os.getenv("EESSI_IGNORE_LMOD_ERROR_A64FX_RUST1650")) then LmodError("Rust 1.65.0 is not supported on A64FX. Please use version 1.75.0 instead.") end
```


And also tested by building a 2022b easyconfig for Zen4:
```
$ eb -f ~/easybuild/easybuild-easyconfigs/easybuild/easyconfigs/f/file/file-5.43-GCCcore-12.2.0.eb 
== Temporary log file in case of crash /tmp/eb-91skhb9h/easybuild-kbx7d5vo.log
== processing EasyBuild easyconfig /home/bob/easybuild/easybuild-easyconfigs/easybuild/easyconfigs/f/file/file-5.43-GCCcore-12.2.0.eb
== building and installing file/5.43-GCCcore-12.2.0...
  >> installation prefix: /home/bob/eessi/versions/2023.06/software/linux/x86_64/amd/zen4/software/file/5.43-GCCcore-12.2.0
== fetching files and verifying checksums...
== Running pre-fetch hook...
== Updated build option 'module-only' to 'True'
== Updated build option 'force' to 'True'
  >> sources:
  >> /data/eb/sources/f/file/file-5.43.tar.gz [SHA256: 8c8015e91ae0e8d0321d94c78239892ef9dbc70c4ade0008c0e95894abfb1991]
== ... (took < 1 sec)
== creating build dir, resetting environment...
  >> build dir: /data/eb/build/file/5.43/GCCcore-12.2.0
== Running post-ready hook...

WARNING: Deprecated functionality, will no longer work in EasyBuild v6.0: Easyconfig parameter 'parallel' is deprecated, use 'max_parallel' or the parallel property instead.; see https://docs.easybuild.io/deprecated-functionality/ for more 
information

== ... (took < 1 sec)
== unpacking [skipped]
== patching [skipped]
== preparing...
== Running pre-prepare hook...
  >> loading toolchain module: GCCcore/12.2.0
  >> defining build environment for GCCcore/12.2.0 toolchain
== Running post-prepare hook...
== ... (took < 1 sec)
== configuring [skipped]
== building [skipped]
== testing [skipped]
== installing [skipped]
== taking care of extensions [skipped]
== restore after iterating...
== ... (took < 1 sec)
== postprocessing [skipped]
== sanity checking [skipped]
== cleaning up [skipped]
== creating module...
== Running pre-module hook...
== Setting EESSI_IGNORE_LMOD_ERROR_ZEN4_GCC1220 in initial environment
  >> generating module file @ /home/bob/eessi/versions/2023.06/software/linux/x86_64/amd/zen4/modules/all/file/5.43-GCCcore-12.2.0.lua
== Running post-module hook...
== Restored original build option 'module_only' to False
== Restored original build option 'force' to True
== Removing EESSI_IGNORE_LMOD_ERROR_ZEN4_GCC1220 in initial environment
== ... (took < 1 sec)
== permissions...
== ... (took < 1 sec)
== packaging...
== ... (took < 1 sec)
  >> running shell command:
        bzip2 /home/bob/eessi/versions/2023.06/software/linux/x86_64/amd/zen4/software/file/5.43-GCCcore-12.2.0/easybuild/easybuild-file-5.43-20250925.130223.log
        [started at: 2025-09-25 13:02:23]
        [working dir: /home/bob/gits/EESSI/software-layer-scripts]
        [output and state saved to /tmp/eb-91skhb9h/run-shell-cmd-output/bzip2-s98xawv1]
  >> command completed: exit 0, ran in < 1s
== COMPLETED: Installation ended successfully (took 1 secs)
== Results of the build can be found in the log file(s) /home/bob/eessi/versions/2023.06/software/linux/x86_64/amd/zen4/software/file/5.43-GCCcore-12.2.0/easybuild/easybuild-file-5.43-20250925.130223.log.bz2
== Running post-easyblock hook...

== Build succeeded for 1 out of 1
== Summary:
   * [SUCCESS] file/5.43-GCCcore-12.2.0
== Temporary log file(s) /tmp/eb-91skhb9h/easybuild-kbx7d5vo.log* have been removed.
== Temporary directory /tmp/eb-91skhb9h has been removed.


$ tail -n 2 ~/eessi/versions/2023.06/software/linux/x86_64/amd/zen4/modules/all/file/5.43-GCCcore-12.2.0.lua 
-- Built with EasyBuild version 5.1.1
if (not os.getenv("EESSI_IGNORE_LMOD_ERROR_ZEN4_GCC1220")) then LmodError("EasyConfigs using toolchains based on GCCcore-12.2.0 are not supported for the Zen4 architecture.\nSee https://www.eessi.io/docs/known_issues/eessi-2023.06/#gcc-1220-and-foss-2022b-based-modules-cannot-be-loaded-on-zen4-architecture") end

```
