### PR TITLE
set `$EPREFIX` correctly for RISC-V clients

### DIFF
--- a/init/modules/EESSI/2023.06.lua
+++ b/init/modules/EESSI/2023.06.lua
@@ -23,7 +23,7 @@ if (subprocess("uname -m"):gsub("\n$","") == "riscv64") then
         eessi_version = os.getenv("EESSI_VERSION_OVERRIDE") or "20240402"
         eessi_repo = "/cvmfs/riscv.eessi.io"
         eessi_prefix = pathJoin(eessi_repo, "versions", eessi_version)
-	eessi_compat_prefix = pathJoin(eessi_prefix, "compat")
+        eessi_compat_prefix = pathJoin(eessi_prefix, "compat")
         if mode() == "load" then
             LmodMessage("RISC-V architecture detected, but there is no RISC-V support yet in the production repository.\n" ..
                         "Automatically switching to version " .. eessi_version .. " of the RISC-V development repository " .. eessi_repo .. ".\n" ..


### PR DESCRIPTION
With #80 being merged, the bot almost got to the point where it would actually install software, but it failed on this line: https://github.com/EESSI/software-layer-scripts/blob/main/EESSI-install-software.sh#L229.

It turned out that `$EPREFIX` was set to `/cvmfs/dev.eessi.io/riscv/versions/2025.06/compat/linux/riscv64`, resulting in:
```
ERROR: Not running in Gentoo Prefix environment, run '/cvmfs/dev.eessi.io/riscv/versions/2025.06/compat/linux/riscv64/startprefix' first!
```

This PR fixes it by introducing an additional variable for the compat layer prefix, which can then be overridden for the different RISC-V versions (20240402 has its own compat layer, 2025.06 won't have that).