### PR TITLE
add `{pre,post}_prepare_hook` for LLVM to solve A64FX build issue by changing `optarch`

### DIFF
--- a/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.8.2-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.8.2-2022b.yml
@@ -1,2 +1,0 @@
-easyconfigs:
-  - LLVM-15.0.5-GCCcore-12.2.0.eb

--- a/easystacks/software.eessi.io/2023.06/rebuilds/20251003-eb-4.8.2-Rust-1.65.0-a64fx-with-optarch.yml
+++ b/easystacks/software.eessi.io/2023.06/rebuilds/20251003-eb-4.8.2-Rust-1.65.0-a64fx-with-optarch.yml
@@ -1,8 +1,0 @@
-# 2025.10.03
-# Rust 1.65.0 had build failures on A64FX (related to its included LLVM),
-# and we worked around by using 1.75.0 and adding a dummy module file for 1.65.0.
-# It should be possible to build it with optarch=march=armv8.2-a, so we need to rebuild it.
-# 
-# See https://github.com/EESSI/software-layer/issues/1213
-easyconfigs:
-  - Rust-1.65.0-GCCcore-12.2.0.eb


### PR DESCRIPTION
Still doing an interactive test build with this file to test it, please don't deploy/merge it yet.