### PR TITLE
Hooks for failing SciPy-Bundle 2023.02 tests on A64FX

### DIFF
--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -1200,7 +1200,7 @@ def pre_test_hook_ignore_failing_tests_SciPybundle(self, *args, **kwargs):
     """
     cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')
     scipy_bundle_versions_nv1 = ('2021.10', '2023.02', '2023.07', '2023.11')
-    scipy_bundle_versions_a64fx = ('2023.06', '2023.07', '2023.11')
+    scipy_bundle_versions_a64fx = ('2023.02', '2023.07', '2023.11')
     scipy_bundle_versions_nvidia_grace = ('2023.02', '2023.07', '2023.11')
     if self.name == 'SciPy-bundle':
         if cpu_target == CPU_TARGET_NEOVERSE_V1 and self.version in scipy_bundle_versions_nv1:


### PR DESCRIPTION
See https://github.com/EESSI/software-layer/pull/1187. This will use `optarch=march=armv8.2-a` for numpy (solves 11 failing tests), and ignores the four failing tests for scipy (which was already there for 2023.07 anyway).