### PR TITLE
use max 12 cores when building libxc for A64FX

### DIFF
--- a/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.8.2-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.8.2-2022b.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - libxc-6.1.0-GCC-12.2.0.eb

--- a/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.8.2-2022b.yml
+++ b/easystacks/software.eessi.io/2023.06/a64fx/eessi-2023.06-eb-4.8.2-2022b.yml
@@ -1,2 +1,0 @@
-easyconfigs:
-  - libxc-6.1.0-GCC-12.2.0.eb

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -1690,6 +1690,7 @@ PARALLELISM_LIMITS = {
     # software-specific limits
     'libxc': {
         '*': (divide_by_factor, 2),
+        CPU_TARGET_A64FX: (set_maximum, 12),
     },
     'MBX': {
         '*': (divide_by_factor, 2),


### PR DESCRIPTION
According to the logs of the already installed version `libxc/6.2.2-GCC-12.3.0`, 12 cores were used:
```
== 2025-04-25 23:51:53,024 build_log.py:267 INFO limiting parallelism to 12 (was 48) for libxc on aarch64/a64fx to avoid out-of-memory failures during building/testing
```