### PR TITLE
Handle nvidia-smi mismatch errors for archdetect.

### DIFF
--- a/init/eessi_archdetect.sh
+++ b/init/eessi_archdetect.sh
@@ -181,6 +181,12 @@ accelpath() {
         nvidia_smi_out=$(mktemp -p /tmp nvidia_smi_out.XXXXX)
         nvidia-smi --query-gpu=gpu_name,count,driver_version,compute_cap --format=csv,noheader 2>&1 > $nvidia_smi_out
         if [[ $? -eq 0 ]]; then
+            if grep -q "Failed to initialize NVML: Driver/library version mismatch" $nvidia_smi_out; then
+                log "ERROR" "accelpath: nvidia-smi command failed with 'Failed to initialize NVML: Driver/library version mismatch'"
+                rm -f $nvidia_smi_out
+                exit 4
+            fi
+
             nvidia_smi_info=$(head -1 $nvidia_smi_out)
             cuda_cc=$(echo $nvidia_smi_info | sed 's/, /,/g' | cut -f4 -d, | sed 's/\.//g')
             log "DEBUG" "accelpath: CUDA compute capability '${cuda_cc}' derived from nvidia-smi output '${nvidia_smi_info}'"


### PR DESCRIPTION
I ran into this as one of our build nodes had the driver mismatch:

```
$ nvidia-smi
Failed to initialize NVML: Driver/library version mismatch
NVML library version: 580.95
```

Sadly, this resulted in `eessi_archdetect.sh` setting `EESSI_ACCEL_SUBDIR` to an empty value, which again caused building CUDA software with `EESSI-extend` to fail with:

```
== FAILED: Installation ended unsuccessfully: It seems you are trying to install an accelerator package TensorFlow into a non-accelerator location
/cvmfs/software.eessi.io/host_injections/2023.06/software/linux/x86_64/intel/cascadelake/software/TensorFlow/2.15.1-foss-2023a-CUDA-12.1.1. You need to reconfigure your installation to target the correct location. (took 0 secs)
== Results of the build can be found in the log file(s) /tmp/eb-ypzupdcc/easybuild-TensorFlow-2.15.1-20251008.110243.Fkxxm.log
== Running post-easyblock hook...
== Summary:
   * [FAILED]  TensorFlow/2.15.1-foss-2023a-CUDA-12.1.1

ERROR: Installation of TensorFlow-2.15.1-foss-2023a-CUDA-12.1.1.eb failed: 'It seems you are trying to install an accelerator package TensorFlow into a non-accelerator location /cvmfs/software.eessi.io/host_injections/2023.06/software/linux/x86_64/intel/cascadelake/software/TensorFlow/2.15.1-foss-2023a-CUDA-12.1.1. You need to reconfigure your installation to target the correct location.'
```
