### PR TITLE
Limit QuantumESPRESSO builds on A64FX to max 6 cores

### DIFF
--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -1712,7 +1712,7 @@ PARALLELISM_LIMITS = {
     },
     'QuantumESPRESSO': {
         CPU_TARGET_A64FX: (set_maximum, 6),
-    }
+    },
     'TensorFlow': {
         '*': (divide_by_factor, 2),
         CPU_TARGET_A64FX: (set_maximum, 8),


### PR DESCRIPTION
And undo the limit for CP2K (introduced in #104), I don't think that was required and it didn't solve the issue in https://github.com/EESSI/software-layer/pull/1220#issuecomment-3385398745. Newer QE versions removed the `maxparallel=1`, and it looks like this makes it run out of memory.

To be sure, I'll add an easystack here that builds both QE and CP2K, just to confirm that both build without issues now.