### PR TITLE
{2025.06, 2023.06} Rebuild EESSI-extend to fix 'module show' issue and use default EESSI version dependent on initialized EESSI version

### DIFF
--- a/EESSI-extend-easybuild.eb
+++ b/EESSI-extend-easybuild.eb
@@ -81,7 +81,7 @@ modextravars = {
 # EASYBUILD_GROUP_WRITABLE_INSTALLDIR
 # EASYBUILD_UMASK
 # EASYBUILD_STICKY_BIT
-modluafooter = """
+local_modluafooter = """
 if (mode() == "load") then
   -- Use a working directory for temporary build files
   if (os.getenv("WORKING_DIR") == nil) then
@@ -215,14 +215,15 @@ if not ( isloaded("EasyBuild") ) then
     load(latest("EasyBuild"))
 end
 easybuild_version = os.getenv("EBVERSIONEASYBUILD") or easybuild_version
-eessi_version = os.getenv("EESSI_VERSION") or "2023.06"
+eessi_version = os.getenv("EESSI_VERSION") or "{_template_version}"
 
 -- Set environment variables that are EasyBuild version specific
 -- Do unload unconditionally, so that even if EB versions were switched in the meantime, this gets unset
 -- This avoids issues where EESSI-extend is first loaded with EB => 5.1 (which set these vars)
 -- but then EB is swapped for a version < 5.1 and then EESSI-extend is unloaded (which would not unset
 -- these vars if we did it conditional on the EB version)
-if mode() == "unload" or mode() == "dependencyCk" or convertToCanonical(easybuild_version) >= convertToCanonical("5.1") then
+if mode() == "unload" or mode() == "dependencyCk" or
+   ( easybuild_version ~= nil and convertToCanonical(easybuild_version) >= convertToCanonical("5.1") ) then
   setenv ("EASYBUILD_STRICT_RPATH_SANITY_CHECK", "1")
   setenv ("EASYBUILD_CUDA_SANITY_CHECK_ERROR_ON_FAILED_CHECKS", "1")
   setenv ("EASYBUILD_FAIL_ON_MOD_FILES_GCCCORE", "1")
@@ -235,5 +236,7 @@ if mode() == "unload" or mode() == "dependencyCk" or convertToCanonical(easybuil
   end
 end
 """
+
+modluafooter = local_modluafooter.format(_template_version=version)
 
 moduleclass = 'devel'

--- a/easystacks/software.eessi.io/2025.06/rebuilds/20251012-eb-5.1.2-EESSI-extend-fix-conditional-and-version.yml
+++ b/easystacks/software.eessi.io/2025.06/rebuilds/20251012-eb-5.1.2-EESSI-extend-fix-conditional-and-version.yml
@@ -1,0 +1,7 @@
+# 2025-10-12
+# Running 'module show EESSI-extend/2025.06-easybuild' throws an error. It seems
+# 'easybuild_version' is nil and therefore an conditional expression cannot be
+# evaluated. Also, it seems not correct that the eessi_version is set to
+# "2023.06" if the environment variable EESSI_VERSION is not set.
+easyconfigs:
+  - EESSI-extend-easybuild.eb


### PR DESCRIPTION
Running `module show EESSI-extend` in EESSI/2025.06 throws the following error

```
Lmod Warning:  Syntax error in file:
/cvmfs/software.eessi.io/versions/2025.06/software/linux/x86_64/intel/haswell/modules/all/EESSI-extend/2025.06-easybuild.lua
 with command: convertToCanonical, one or more arguments are not strings.

While processing the following module(s):
    Module fullname                 Module Filename
    ---------------                 ---------------
    EESSI-extend/2025.06-easybuild  /cvmfs/software.eessi.io/versions/2025.06/software/linux/x86_64/intel/haswell/modules/all/EESSI-extend/2025.06-easybuild.lua

Lmod has detected the following error:  Unable to load module because of error when evaluating modulefile:
     /cvmfs/software.eessi.io/versions/2025.06/software/linux/x86_64/intel/haswell/modules/all/EESSI-extend/2025.06-easybuild.lua:
[string "help([==[..."]:239: attempt to compare string with nil
     Please check the modulefile and especially if there is a line number specified in the above message
While processing the following module(s):
    Module fullname                 Module Filename
    ---------------                 ---------------
    EESSI-extend/2025.06-easybuild  /cvmfs/software.eessi.io/versions/2025.06/software/linux/x86_64/intel/haswell/modules/all/EESSI-extend/2025.06-easybuild.lua
```

It looks like `easybuild_version` is not defined when the conditional expression in line 239 (see below) is evaluated

```lua
if mode() == "unload" or mode() == "dependencyCk" or convertToCanonical(easybuild_version) >= convertToCanonical("5.1") then
```

Also, it seems not correct to set `eessi_version` to `2023.06` for EESSI/2025.06 in case `$EESSI_VERSION` is undefined. See line 232 below
```lua
eessi_version = os.getenv("EESSI_VERSION") or "2023.06"
```
