### PR TITLE
only use `$EESSI_VERSION` in `init/eessi_defaults`

### DIFF
--- a/init/eessi_defaults
+++ b/init/eessi_defaults
@@ -1,4 +1,3 @@
-# define default values for some EESSI_* environment variables
 #
 # This file is part of the EESSI software layer,
 # see https://github.com/EESSI/software-layer
@@ -23,11 +22,10 @@ if [[ $(uname -m) == "riscv64" ]]; then
             echo "For more details about this repository, see https://www.eessi.io/docs/repositories/riscv.eessi.io/."
             echo ""
         fi
-    # allow for version suffixes in 2025.06 (e.g. 2025.06-001)
     elif [[ "${EESSI_VERSION}" == "2025.06"* ]]; then
         export EESSI_CVMFS_REPO="${EESSI_CVMFS_REPO_OVERRIDE:=/cvmfs/dev.eessi.io/riscv}"
-        export EESSI_COMPAT_LAYER_DIR="/cvmfs/software.eessi.io/versions/${EESSI_VERSION_DEFAULT}/compat/linux/$(uname -m)"
-        export EESSI_INIT_PREFIX="/cvmfs/software.eessi.io/versions/${EESSI_VERSION_DEFAULT}/init"
+        export EESSI_COMPAT_LAYER_DIR="/cvmfs/software.eessi.io/versions/${EESSI_VERSION}/compat/linux/$(uname -m)"
+        export EESSI_INIT_PREFIX="/cvmfs/software.eessi.io/versions/${EESSI_VERSION}/init"
         if [[ -z ${EESSI_SILENT+x} ]]; then
             echo "This EESSI production version only provides a RISC-V compatibility layer,"
             echo "software installations are provided by the EESSI development repository at ${EESSI_CVMFS_REPO}."


### PR DESCRIPTION
I think I had a good reason to use `$EESSI_VERSION_DEFAULT` in the RISC-V if statement, but that's now giving me issues: the `EESSI-install-software.sh` script sources this file from the git repo, and then `__EESSI_VERSION_DEFAULT__` is not replaced by an actual value. This leads to paths like `EESSI_COMPAT_LAYER_DIR=/cvmfs/software.eessi.io/versions/__EESSI_VERSION_DEFAULT__/compat/linux/riscv64`. 

Instead, I'm now just setting `$EESSI_VERSION` near the top, and then use it everywhere.