### PR TITLE
Ignore failing scipy tests on neoverse_v1 and a64fx for SciPy-bundle 2024.05

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-2024a.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-2024a.yml
@@ -1,2 +1,0 @@
-easyconfigs:
-  - SciPy-bundle-2024.05-gfbf-2024a.eb


### PR DESCRIPTION
See https://github.com/EESSI/software-layer/pull/1210/#issuecomment-3456549182 and https://github.com/EESSI/software-layer/pull/1210/#issuecomment-3457989041.