### PR TITLE
New workaround for PSM3 issues causing test failures in 2025.06

### DIFF
--- a/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.2-2025a.yml
+++ b/easystacks/software.eessi.io/2023.06/eessi-2023.06-eb-5.1.2-2025a.yml
@@ -1,2 +1,0 @@
-easyconfigs:
-  - cowsay-3.04.eb


### PR DESCRIPTION
See https://github.com/EESSI/software-layer/pull/1288: test step is failing for all x86_64 targets. I could sort of reproduce it interactively, but with a different error, so I'm going to debug it a bit more here.


---

edit: okay, just to make it easier to find the conclusions, I'm putting the conclusions here:

The ReFrame logs of the failed tests done by the bot contained PSM3 timeout messages like:
```
libfabric:398:1762504388::psm3:av:psmx3_epid_to_epaddr():234<warn> x86-64-generic-node1.int.aws-rocky88-202310.eessi.io:rank3: psm3_ep_connect returned error Operation timed out, remot
e epid=0x18d00000008:0:ffff0a000051.Try setting FI_PSM3_CONN_TIMEOUT to a larger value (current: 10 seconds). Aborting
[x86-64-generic-node1:00398] *** Process received signal ***
[x86-64-generic-node1:00398] Signal: Aborted (6)
[x86-64-generic-node1:00398] Signal code:  (-6)
libfabric:395:1762504388::psm3:av:psmx3_epid_to_epaddr():234<warn> x86-64-generic-node1.int.aws-rocky88-202310.eessi.io:rank0: psm3_ep_connect returned error Operation timed out, remot
e epid=0x18c00000008:0:ffff0a000051.Try setting FI_PSM3_CONN_TIMEOUT to a larger value (current: 10 seconds). Aborting
[x86-64-generic-node1:00395] *** Process received signal ***
[x86-64-generic-node1:00395] Signal: Aborted (6)
[x86-64-generic-node1:00395] Signal code:  (-6)
[x86-64-generic-node1:00398] [ 0] [x86-64-generic-node1:00400] [ 0] /cvmfs/software.eessi.io/versions/2025.06/compat/linux/x86_64/lib/../lib64/libc.so.6(+0x3be10) [0x14e5d6ec0e10]
[x86-64-generic-node1:00400] [ 1] [x86-64-generic-node1:00396] [ 0] /cvmfs/software.eessi.io/versions/2025.06/compat/linux/x86_64/lib/../lib64/libc.so.6(+0x3be10) [0x1512ef287e10]
[x86-64-generic-node1:00396] [ 1] [x86-64-generic-node1:00401] [ 0] /cvmfs/software.eessi.io/versions/2025.06/compat/linux/x86_64/lib/../lib64/libc.so.6(+0x3be10) [0x14eff332ce10]
[x86-64-generic-node1:00401] [ 1] [x86-64-generic-node1:00395] [ 0] /cvmfs/software.eessi.io/versions/2025.06/compat/linux/x86_64/lib/../lib64/libc.so.6(+0x3be10) [0x1484dfa31e10]
[x86-64-generic-node1:00395] [ 1] [x86-64-generic-node1:00402] [ 0] /cvmfs/software.eessi.io/versions/2025.06/compat/linux/x86_64/lib/../lib64/libc.so.6(+0x3be10) [0x14c6945f1e10]
[x86-64-generic-node1:00402] [ 1] [x86-64-generic-node1:00397] [ 0] /cvmfs/software.eessi.io/versions/2025.06/compat/linux/x86_64/lib/../lib64/libc.so.6(+0x3be10) [0x14a47acd7e10]
[x86-64-generic-node1:00397] [ 1] [x86-64-generic-node1:00399] [ 0] /cvmfs/software.eessi.io/versions/2025.06/compat/linux/x86_64/lib/../lib64/libc.so.6(+0x3be10) [0x1552fa090e10]
```

Initially I could not reproduce that with a manually submitted Slurm job on the AWS cluster, though I did get this:
```
--------------------------------------------------------------------------
A request was made to bind that would require binding
processes to more cpus than are available in your allocation:

   Application:     osu_bw
   #processes:      2
   Mapping policy:  BYCORE
   Binding policy:  CORE

You can override this protection by adding the "overload-allowed"
option to your binding directive.
--------------------------------------------------------------------------
```
which I could solve by setting `export PRTE_MCA_rmaps_default_mapping_policy=:oversubscribe`.

Then I noticed that `test_suite.sh` has a workaround that sets `https://github.com/EESSI/software-layer-scripts/blob/main/test_suite.sh#L174`, see https://github.com/EESSI/software-layer-scripts/blob/d34191695feb0bad026a9d90b7f92b70870d071f/test_suite.sh#L174. By adding that same thing to my jobscript, I could reproduce the issue and got the PSM3 timeouts as well. While trying to find a solution, I found https://github.com/easybuilders/easybuild-easyconfigs/issues/18925 again, and tried another workaround from that issue. Setting `FI_PROVIDER="^psm3"` completely disables the PSM3 provider, and that solves the issue.