### PR TITLE
Infer the ReFrame partition name based on the node_type listed in the job's cfg

### DIFF
--- a/bot/test.sh
+++ b/bot/test.sh
@@ -189,6 +189,10 @@ EESSI_OS_TYPE=$(cfg_get_value "architecture" "os_type")
 export EESSI_OS_TYPE=${EESSI_OS_TYPE:-linux}
 echo "bot/test.sh: EESSI_OS_TYPE='${EESSI_OS_TYPE}'"
 
+# Get node_type from .architecture.node_type in ${JOB_CFG_FILE}
+export BOT_NODE_TYPE=$(cfg_get_value "architecture" "node_type")
+echo "bot/test.sh: BOT_NODE_TYPE='${BOT_NODE_TYPE}"
+
 # prepare arguments to eessi_container.sh common to build and tarball steps
 declare -a COMMON_ARGS=()
 COMMON_ARGS+=("--verbose")
@@ -236,6 +240,9 @@ if [[ ${EESSI_SOFTWARE_SUBDIR_OVERRIDE} =~ .*/generic$ ]]; then
 fi
 if [[ ${SHARED_FS_PATH} ]]; then
     TEST_SUITE_ARGS+=("--shared-fs-path" "${SHARED_FS_PATH}")
+fi
+if [[ ${BOT_NODE_TYPE} ]]; then
+    TEST_SUITE_ARGS+=("--partition" "${BOT_NODE_TYPE}")
 fi
 # [[ ! -z ${BUILD_LOGS_DIR} ]] && TEST_SUITE_ARGS+=("--build-logs-dir" "${BUILD_LOGS_DIR}")
 # [[ ! -z ${SHARED_FS_PATH} ]] && TEST_SUITE_ARGS+=("--shared-fs-path" "${SHARED_FS_PATH}")

--- a/test_suite.sh
+++ b/test_suite.sh
@@ -192,6 +192,8 @@ if [[ $? -eq 1 ]]; then
     # This fallback can be scrapped once all bots have adopted the new naming convention
     # (i.e. using the node_type name from app.cfg) for ReFrame partitions
     # Get the correct partition name
+    echo "Falling back to old naming scheme for REFRAME_PARTITION_NAME."
+    echo "This naming scheme is deprecated, please update your partition names in the ReFrame config file."
     REFRAME_PARTITION_NAME=${EESSI_SOFTWARE_SUBDIR//\//_}
     if [ ! -z "$EESSI_ACCELERATOR_TARGET_OVERRIDE" ]; then
         REFRAME_PARTITION_NAME=${REFRAME_PARTITION_NAME}_${EESSI_ACCELERATOR_TARGET_OVERRIDE//\//_}

--- a/test_suite.sh
+++ b/test_suite.sh
@@ -183,6 +183,22 @@ else
     fatal_error "Failed to run 'reframe --version'"
 fi
 
+# Check if the partition specified by RFM_SYSTEM is in the config file
+# Redirect to /dev/null because we don't want to print an ERROR, we want to try a fallback
+reframe --show-config | grep -v "could not find a configuration entry for the requested system/partition combination" > /dev/null
+if [[ $? -eq 1 ]]; then
+    # There was a match by grep, so we failed to find the system/partition combination
+    # Try the previous approach for backwards compatibility
+    # This fallback can be scrapped once all bots have adopted the new naming convention
+    # (i.e. using the node_type name from app.cfg) for ReFrame partitions
+    # Get the correct partition name
+    REFRAME_PARTITION_NAME=${EESSI_SOFTWARE_SUBDIR//\//_}
+    if [ ! -z "$EESSI_ACCELERATOR_TARGET_OVERRIDE" ]; then
+        REFRAME_PARTITION_NAME=${REFRAME_PARTITION_NAME}_${EESSI_ACCELERATOR_TARGET_OVERRIDE//\//_}
+    fi
+    echo "Constructed partition name based on EESSI_SOFTWARE_SUBDIR and EESSI_ACCELERATOR_TARGET: ${REFRAME_PARTITION_NAME}"
+fi    
+
 # Get the subset of test names based on the test mapping and tags (e.g. CI, 1_node)
 module_list="module_files.list.txt"
 mapping_config="tests/eessi_test_mapping/software_to_tests.yml"

--- a/test_suite.sh
+++ b/test_suite.sh
@@ -199,6 +199,9 @@ if [[ $? -eq 1 ]]; then
     echo "Constructed partition name based on EESSI_SOFTWARE_SUBDIR and EESSI_ACCELERATOR_TARGET: ${REFRAME_PARTITION_NAME}"
 fi    
 
+# Log the config for this partition:
+reframe --show-config
+
 # Get the subset of test names based on the test mapping and tags (e.g. CI, 1_node)
 module_list="module_files.list.txt"
 mapping_config="tests/eessi_test_mapping/software_to_tests.yml"

--- a/test_suite.sh
+++ b/test_suite.sh
@@ -13,6 +13,7 @@
 display_help() {
   echo "usage: $0 [OPTIONS]"
   echo "  -g | --generic         -  instructs script to test for generic architecture target"
+  echo "  -p | --partition       -  the partition name on which to test (used by ReFrame to load the right config)"
   echo "  -h | --help            -  display this usage information"
   echo "  -x | --http-proxy URL  -  provides URL for the environment variable http_proxy"
   echo "  -y | --https-proxy URL -  provides URL for the environment variable https_proxy"
@@ -25,6 +26,10 @@ while [[ $# -gt 0 ]]; do
     -g|--generic)
       DETECTION_PARAMETERS="--generic"
       shift
+      ;;
+    -p|--partition)
+      REFRAME_PARTITION_NAME="${2}"
+      shift 2
       ;;
     -h|--help)
       display_help  # Call your function
@@ -152,13 +157,6 @@ fi
 export RFM_CHECK_SEARCH_PATH=$TESTSUITEPREFIX/eessi/testsuite/tests
 export RFM_CHECK_SEARCH_RECURSIVE=1
 export RFM_PREFIX=$PWD/reframe_runs
-
-# Get the correct partition name
-REFRAME_PARTITION_NAME=${EESSI_SOFTWARE_SUBDIR//\//_}
-if [ ! -z "$EESSI_ACCELERATOR_TARGET_OVERRIDE" ]; then
-    REFRAME_PARTITION_NAME=${REFRAME_PARTITION_NAME}_${EESSI_ACCELERATOR_TARGET_OVERRIDE//\//_}
-fi
-echo "Constructed partition name based on EESSI_SOFTWARE_SUBDIR and EESSI_ACCELERATOR_TARGET: ${REFRAME_PARTITION_NAME}"
 
 # Set the reframe system name, including partition
 export RFM_SYSTEM="BotBuildTests:${REFRAME_PARTITION_NAME}"

--- a/test_suite.sh
+++ b/test_suite.sh
@@ -199,6 +199,7 @@ if [[ $? -eq 1 ]]; then
         REFRAME_PARTITION_NAME=${REFRAME_PARTITION_NAME}_${EESSI_ACCELERATOR_TARGET_OVERRIDE//\//_}
     fi
     echo "Constructed partition name based on EESSI_SOFTWARE_SUBDIR and EESSI_ACCELERATOR_TARGET: ${REFRAME_PARTITION_NAME}"
+    export RFM_SYSTEM="BotBuildTests:${REFRAME_PARTITION_NAME}"
 fi    
 
 # Log the config for this partition:


### PR DESCRIPTION
Currently, we construct a ReFrame partition name based on the software subdir that is being used. E.g. the constructed partition name would be `x86_64_intel_skylake_avx512` on an intel skylake node. However, this leads to failures in the test step when cross compiling:

```
ERROR: failed to load configuration: could not find a configuration entry for the requested system/partition combination: 'BotBuildTests:aarch64_neoverse_v1_accel_nvidia_cc90'
```

Because ReFrame will look for a partition `aarch64_neoverse_v1_accel_nvidia_cc90` in the ReFrame config, but that doesn't exist. We _could_ of course define 5 identical partitions `aarch64_neoverse_v1_accel_nvidia_ccXX` (with XX=70, 80, 90, 100, 120), but there's no point: they all represent the same physical node, with the same physical properties (namely: it has no GPU!).

Rather than this duplication, we should really have _one_ ReFrame partition that corresponds to the _actual_ hardware in the node, and make sure that whenever that node is used for building, this partition config is used. With the change of `arch_target_map` to `node_type_map` on the bot side, I silently introduced a property in the `cfg/job.cfg` file that allows us to do this: it stores the `node_type`, i.e. the keys in the `node_type_map`. Using this means one has to use the _same names_ for partitions in the `app.cfg` and the ReFrame config file, which I think is intuitive. 

The way in which I implemented this is that I retrieve the `node_type` value in the `bot/test.sh`, then pass it as an argument to `test_suite.sh`. I also made sure that it still works with the old configuration.

Proof that this works:
- This shows the success before any changes https://github.com/casparvl/software-layer/pull/5#issuecomment-3521314407
- This shows that it failed if I implemented the new feature, but _before_ implementing the backwards compatibility https://github.com/casparvl/software-layer/pull/5#issuecomment-3521655212
- This shows the success with the new feature _and_ the corresponding name change in the ReFrame config file https://github.com/casparvl/software-layer/pull/5#issuecomment-3521679777
- And this shows the success with the new feature, including backwards compatibility, and a partition for which the new naming scheme was _not_ yet used in the ReFrame config file https://github.com/casparvl/software-layer/pull/5#issuecomment-3522284718