### PR TITLE
use `head -n 1` instead of `head -1` (likewise for `tail`)

### DIFF
--- a/EESSI-install-software.sh
+++ b/EESSI-install-software.sh
@@ -207,7 +207,7 @@ fi
 
 # the install_scripts.sh script relies on knowing the location of the PR diff
 # assume there's only one diff file that corresponds to the PR patch file
-pr_diff=$(ls [0-9]*.diff | head -1)
+pr_diff=$(ls [0-9]*.diff | head -n 1)
 export PR_DIFF="$PWD/$pr_diff"
 
 # Only run install_scripts.sh if not in dev.eessi.io for security

--- a/bot/test.sh
+++ b/bot/test.sh
@@ -100,7 +100,7 @@ if [[ ! -z ${SINGULARITY_CACHEDIR} ]]; then
 fi
 
 # try to determine tmp directory from build job
-RESUME_DIR=$(grep 'Using .* as tmp directory' slurm-${SLURM_JOBID}.out | head -1 | awk '{print $2}')
+RESUME_DIR=$(grep 'Using .* as tmp directory' slurm-${SLURM_JOBID}.out | head -n 1 | awk '{print $2}')
 
 if [[ -z ${RESUME_DIR} ]]; then
   RESUME_TGZ=${PWD}/previous_tmp/build_step/$(ls previous_tmp/build_step)

--- a/init/eessi_archdetect.sh
+++ b/init/eessi_archdetect.sh
@@ -181,7 +181,7 @@ accelpath() {
         nvidia_smi_out=$(mktemp -p /tmp nvidia_smi_out.XXXXX)
         nvidia-smi --query-gpu=gpu_name,count,driver_version,compute_cap --format=csv,noheader 2>&1 > $nvidia_smi_out
         if [[ $? -eq 0 ]]; then
-            nvidia_smi_info=$(head -1 $nvidia_smi_out)
+            nvidia_smi_info=$(head -n 1 $nvidia_smi_out)
             cuda_cc=$(echo $nvidia_smi_info | sed 's/, /,/g' | cut -f4 -d, | sed 's/\.//g')
             log "DEBUG" "accelpath: CUDA compute capability '${cuda_cc}' derived from nvidia-smi output '${nvidia_smi_info}'"
             res="accel/nvidia/cc${cuda_cc}"

--- a/init/eessi_environment_variables
+++ b/init/eessi_environment_variables
@@ -59,7 +59,7 @@ if [ -d $EESSI_PREFIX ]; then
       fi
 
       if [[ $accelpath_exit_code -eq 0 ]]; then
-          export EESSI_ACCEL_SUBDIR=$(tail -1 $tmpout && rm -f $tmpout)
+          export EESSI_ACCEL_SUBDIR=$(tail -n 1 $tmpout && rm -f $tmpout)
           if [ -z ${EESSI_ACCEL_SUBDIR} ]; then
               error "accelerator detection with archdetect worked, but no result was returned?!"
           else

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -20,7 +20,7 @@ source ${base_dir}/init/eessi_defaults
 # Make sure we clone the latest version. This assumes versions are of the format "v1.2.3", then picks the latest
 # then checks it out
 TEST_CLONE="git clone https://github.com/EESSI/test-suite EESSI-test-suite && cd EESSI-test-suite"
-LATEST_VERSION="VERSION=\$(git tag | grep '^v[0-9]\+\.[0-9]\+\.[0-9]\+$' | sort -t. -k 1,1n -k 2,2n -k 3,3n | tail -1)"
+LATEST_VERSION="VERSION=\$(git tag | grep '^v[0-9]\+\.[0-9]\+\.[0-9]\+$' | sort -t. -k 1,1n -k 2,2n -k 3,3n | tail -n 1)"
 CHECKOUT_LATEST="git checkout \${VERSION}"
 
 # Git clone has to be run in compat layer, to make the git command available

--- a/scripts/gpu_support/nvidia/link_nvidia_host_libraries.sh
+++ b/scripts/gpu_support/nvidia/link_nvidia_host_libraries.sh
@@ -223,7 +223,7 @@ check_nvidia_smi_info() {
         
         if nvidia-smi --query-gpu=gpu_name,count,driver_version,compute_cap --format=csv,noheader > "$nvidia_smi_out" 2>&1
         then
-            nvidia_smi_info=$(head -1 "${nvidia_smi_out}")
+            nvidia_smi_info=$(head -n 1 "${nvidia_smi_out}")
             HOST_GPU_CUDA_VERSION=$(echo "${nvidia_smi_info}" | sed 's/, /,/g' | cut -f4 -d,)
             HOST_GPU_DRIVER_VERSION=$(echo "${nvidia_smi_info}" | sed 's/, /,/g' | cut -f3 -d,)
             echo_green "Found host CUDA version ${HOST_GPU_CUDA_VERSION}"


### PR DESCRIPTION
On some systems (like MareNostrum 5) `head -1` and `tail -1` doesn't work:

```
$ echo boo | tail -1
tail: option used in invalid context -- 1
```

Seems to be caused by an alias that's used:
```
alias tail='tail ---disable-inotify'
```

On MareNostrum 5 GPU nodes, this leads to broken GPU detection:
```
tail: option used in invalid context -- 1
ERROR: accelerator detection with archdetect worked, but no result was returned?!
```