### PR TITLE
Prevent that `lscpu | grep Flags` fails on systems that don't report any flags

### DIFF
--- a/bot/build.sh
+++ b/bot/build.sh
@@ -176,7 +176,7 @@ lscpu > _bot_job${SLURM_JOB_ID}.lscpu
 cat /etc/os-release > _bot_job${SLURM_JOB_ID}.os
 
 # Also: fetch CPU flags into an array, so that we can implement a hard check against a reference
-lscpu_flags_line=$(lscpu | grep "Flags:")
+lscpu_flags_line=$(lscpu | grep "Flags:" || echo "")
 # strip leading "Flags:" and spaces, and put result in a bash array
 if [[ $lscpu_flags =~ Flags:\ (.*) ]]; then lscpu_flags=(${BASH_REMATCH[1]}); fi
 # for now, just print


### PR DESCRIPTION
The `bot/build.sh` suddenly failed on a RISC-V node. This node doesn't have any `Flags` field in the `lscpu` output:

```
$ lscpu 
Architecture:          riscv64
  Byte Order:          Little Endian
CPU(s):                4
  On-line CPU(s) list: 0-3
```

And this causes the `grep` command introduced in https://github.com/EESSI/software-layer-scripts/pull/123 to return 1, and in turn that makes the entire script fail (because of `set -e`). By adding `|| echo "")` it will just return an empty string in this case.