### PR TITLE
Disable `--with-sysroot` option for UCX

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-ucx.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-ucx.yml
@@ -1,5 +1,0 @@
-easyconfigs:
-  - UCX-1.16.0-GCCcore-13.3.0.eb:
-      options:
-        rebuild: True
-  - Cgl-0.60.8-foss-2024a.eb


### PR DESCRIPTION
In both https://github.com/EESSI/software-layer/pull/1299#issuecomment-3528150575 and https://github.com/EESSI/software-layer/pull/1294/#issuecomment-3554645553 we've seen the following error for applications that try to link against UCX:
```
../../libtool: line 3232: cd: =/cvmfs/software.eessi.io/versions/2025.06/software/linux/aarch64/nvidia/grace/software/UCX/1.16.0-GCCcore-13.3.0/lib: No such file or directory
libtool: link: warning: cannot determine absolute directory name of `=/cvmfs/software.eessi.io/versions/2025.06/software/linux/aarch64/nvidia/grace/software/UCX/1.16.0-GCCcore-13.3.0/lib'
grep: =/cvmfs/software.eessi.io/versions/2025.06/software/linux/aarch64/nvidia/grace/software/UCX/1.16.0-GCCcore-13.3.0/lib/libuct.la: No such file or directory
/cvmfs/software.eessi.io/versions/2025.06/compat/linux/aarch64/bin/sed: can't read =/cvmfs/software.eessi.io/versions/2025.06/software/linux/aarch64/nvidia/grace/software/UCX/1.16.0-GCCcore-13.3.0/lib/libuct.la: No such file or directory
libtool: link: `=/cvmfs/software.eessi.io/versions/2025.06/software/linux/aarch64/nvidia/grace/software/UCX/1.16.0-GCCcore-13.3.0/lib/libuct.la' is not a valid libtool archive
```

UCX's `$EBROOTUCX/lib/*.la` files contain these paths prefixed with a `=`, which are, according to ChatGPT, "paths relative to the installed libdir of this library". They're not relative though, but absolute paths, and this seems to be caused by the `--with-sysroot` option. Compiling it without that option should be fine, it should even use the compiler's sysroot in this case:
```
  --with-sysroot=DIR Search for dependent libraries within DIR
                        (or the compiler's sysroot if not specified).
```

To make sure that this works, I'll do test builds of a few UCX versions here.