### PR TITLE
reduce number of cores used for Qt6 builds

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-qt6.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.2-qt6.yml
@@ -1,5 +1,0 @@
-easyconfigs:
-  - Qt6-6.9.3-GCCcore-14.2.0.eb:
-      options:
-        # see https://github.com/easybuilders/easybuild-easyconfigs/pull/24356
-        from-commit: c057c3242d4a947ae30358ea283659ff0d1a3d17


### PR DESCRIPTION
See https://github.com/EESSI/software-layer/pull/1341, many Arm builds failed because they ran out of memory.