### PR TITLE
also update `parallel` template value in hook that limits parallelism

### DIFF
--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -278,6 +278,9 @@ def post_ready_hook(self, *args, **kwargs):
             self.cfg.parallel = new_parallel
         else:
             self.cfg['parallel'] = new_parallel
+        # also update the "parallel" template value
+        self.cfg.template_values['parallel'] = new_parallel
+        self.cfg.generate_template_values()
         msg = "limiting parallelism to %s (was %s, derived parallelism %s) for %s on %s "
         msg+ "to avoid out-of-memory failures during building/testing"
         print_msg(msg % (new_parallel, curr_parallel, session_parallel, self.name, cpu_target), log=self.log)


### PR DESCRIPTION
This should make sure that for instance Qt uses the right value here: https://github.com/easybuilders/easybuild-easyconfigs/blob/develop/easybuild/easyconfigs/q/Qt6/Qt6-6.9.3-GCCcore-14.2.0.eb#L81.

With this extra bit of code I correctly see `export NINJAFLAGS="-j8"` for Qt6's configure/build step, instead of `export NINJAFLAGS="-j16" &&  ninja -v -j 8`