### PR TITLE
fix bind mount bug when using proxy

### DIFF
--- a/eessi_container.sh
+++ b/eessi_container.sh
@@ -818,7 +818,7 @@ if [[ ! -z ${http_proxy} ]]; then
             fi
             [[ ${VERBOSE} -eq 1 ]] && echo "Added bind mount: ${src}:${target}"
             ;;
-    esac  
+    esac
 fi
 
 # 4. set up vars and dirs specific to a scenario


### PR DESCRIPTION
When a proxy is used to provide access to CernVM-FS on a compute node, we add the proxy configuration to `/etc/cvmfs/default.local`. The current code checked if this directory was already listed in the `$BIND_PATHS`, and exited if so.

However, exiting is too strict. We only should exit if the source of the existing bind mount with destination `/etc/cvmfs/default.local` is different to the currently changed source (where we're adding the proxy settings). If the sources are the same (we verify via `readlink -f`), we don't need to add the bind mount to `$BIND_PATHS` again (all is fine).

This PR adds the function `check_bind_paths_for_target ` that checks whether a given `src:target` bind mount is already in `$BIND_PATHS`. This function is then used to decide whether the given bind mount has to be added or not _OR_ if an ambiguous situation has occurred (different sources for same target) and thus `eessi_container.sh` shall terminate immediately.

Code was tested in https://github.com/trz42/software-layer/pull/93 via https://github.com/trz42/software-layer-scripts/tree/debug_bind_mount_issue