### PR TITLE
fix typo in `eessi_container.sh` fixing the script when http_proxy is set

### DIFF
--- a/eessi_container.sh
+++ b/eessi_container.sh
@@ -828,7 +828,7 @@ if [[ ! -z ${http_proxy} ]]; then
             ;;
         2)
             # target not found - safe to add
-            if [[ -z ${BIND_PATH} ]]; then
+            if [[ -z ${BIND_PATHS} ]]; then
                 BIND_PATHS="${src}:${target}"
             else
                 BIND_PATHS="${BIND_PATHS},${src}:${target}"


### PR DESCRIPTION
When http_proxy is set, the condition `[[ -z ${BIND_PATH} ]]` evaluates true and the code replaces the entire BIND_PATHS with **only** the newly added mapping for default.local
