### PR TITLE
Apply hooks in install_cuda_and_libraries

### DIFF
--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -697,7 +697,7 @@ def pre_fetch_hook_check_installation_path(self, *args, **kwargs):
     strict_eessi_installation = (
         bool(re.search(EESSI_INSTALLATION_REGEX, self.installdir)) or
         self.installdir.startswith(HOST_INJECTIONS_LOCATION))
-    if strict_eessi_installation:
+    if strict_eessi_installation and not os.getenv("EESSI_OVERRIDE_STRICT_INSTALLPATH_CHECK"):
         dependency_names = self.cfg.dependency_names()
         if self.cfg.name in accelerator_deps or any(dep in dependency_names for dep in accelerator_deps):
             # Make sure the path is an accelerator location
@@ -1089,7 +1089,7 @@ def pre_configure_hook_graphviz(self, *args, **kwargs):
         # Replace --with-ltdl-lib and --with-zlibdir options defined in the EC to point to compat layer
         lib_dir = os.path.join(usr_dir, 'lib64')
         new_items = set()
-        # Add to the new_items all the old items except the `--with-ltdl-lib` and `--with-ltdl-lib` for 
+        # Add to the new_items all the old items except the `--with-ltdl-lib` and `--with-ltdl-lib` for
         # which we fix the lib dir to lib64 instead of lib
         for item in old_items:
             if item.startswith('--with-ltdl-lib'):
@@ -1483,7 +1483,7 @@ def pre_test_hook_ignore_failing_tests_OpenBabel_a64fx(self, *args, **kwargs):
     Pre-test hook for OpenBabel: skip timeout tests for OpenBabel 3.1.1 on aarch64/a64fx
     see https://github.com/EESSI/software-layer/pull/1332#issuecomment-3877255228
     the `testroundtrip.py` test reads and writes tens of thousands of small files.
-    The test works fine when manually ran with EESSI-extend either directly or inside an eessi_container, but 
+    The test works fine when manually ran with EESSI-extend either directly or inside an eessi_container, but
     consistently fails with the bot
     """
     cpu_target = get_eessi_envvar('EESSI_SOFTWARE_SUBDIR')

--- a/scripts/gpu_support/nvidia/install_cuda_and_libraries.sh
+++ b/scripts/gpu_support/nvidia/install_cuda_and_libraries.sh
@@ -149,10 +149,9 @@ for EASYSTACK_FILE in ${TOPDIR}/easystacks/eessi-*CUDA*.yml; do
     MODULEPATH=${EASYBUILD_INSTALLPATH}/.modules/all
     echo "set MODULEPATH=${MODULEPATH}"
 
-    # We don't want hooks used in this install, we need vanilla installations
-    touch "${tmpdir}"/none.py
-    export EASYBUILD_HOOKS="${tmpdir}/none.py"
-    
+    # We need to skip the hook that checks if CUDA software installed in an accelerator-specific prefix
+    export EESSI_OVERRIDE_STRICT_INSTALLPATH_CHECK=1
+
     # show EasyBuild configuration
     echo "Show EasyBuild configuration"
     eb --show-config
@@ -238,8 +237,6 @@ for EASYSTACK_FILE in ${TOPDIR}/easystacks/eessi-*CUDA*.yml; do
     #        is run, it is not reinstalled.
     #  - ${accept_eula_opt}: We only set the --accept-eula-for=CUDA option if CUDA will be installed and if
     #        this script was called with the argument --accept-cuda-eula.
-    #  - hooks: We don't want hooks used in this install, we need vanilla
-    #        installations of CUDA and/or other libraries
     #  - easystack: Path to easystack file that defines which packages shall be
     #        installed
     accept_eula_opt=
@@ -256,7 +253,6 @@ for EASYSTACK_FILE in ${TOPDIR}/easystacks/eessi-*CUDA*.yml; do
     touch "$tmpdir"/none.py
     eb_args="--prefix=$tmpdir"
     eb_args="$eb_args --installpath-modules=${EASYBUILD_INSTALLPATH}/.modules"
-    eb_args="$eb_args --hooks="$tmpdir"/none.py"
     eb_args="$eb_args --easystack ${EASYSTACK_FILE}"
     if [[ ! -z ${accept_eula_opt} ]]; then
         eb_args="$eb_args --accept-eula-for=$accept_eula_opt"


### PR DESCRIPTION
Make sure the hooks are applied in install_cuda_and_libraries, but that the directory check is skipped, as we INTEND to install in an exceptional (i.e. non-accelerator) path.

This solves an issue I had running `install_cuda_and_libraries.sh` on an H100 system. It would cause the CUDA sanity check to fail since the hooks weren't being applied that would turn the `9.0a` CC into a `9.0`.

Originally, we skipped the hooks alltogether. But the real solution is to apply the hooks, but make sure that the hook that does the installation path check is skipped.