### PR TITLE
add hook that makes BLIS fall back to zen3 on zen5

### DIFF
--- a/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.1.yml
+++ b/easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.1.1.yml
@@ -1,2 +1,0 @@
-easyconfigs:
-  - BLIS-1.0-GCC-13.3.0.eb


### PR DESCRIPTION
This basically does the same thing as https://github.com/easybuilders/easybuild-easyblocks/pull/4034, but that doesn't work on our AWS Zen5 VM, becausae archspec detects it as zen4.