### PR TITLE
accept missing ptx for cuDNN 9.15.0.57

### DIFF
--- a/scripts/gpu_support/nvidia/easystacks/2025.06/eessi-2025.06-eb-5.2.0-CUDA-host-injections.yml
+++ b/scripts/gpu_support/nvidia/easystacks/2025.06/eessi-2025.06-eb-5.2.0-CUDA-host-injections.yml
@@ -21,3 +21,4 @@ easyconfigs:
   - cuDNN-9.15.0.57-CUDA-12.9.1.eb:
       options:
         accept-eula-for: cuDNN
+        cuda-sanity-check-accept-missing-ptx: True


### PR DESCRIPTION
Without this the build fails:
```
== sanity checking...
  >> file 'include/cudnn.h' found: OK
  >> file 'lib64/libcudnn_adv_static.a' found: OK
  >> file 'lib64/libcudnn_cnn_static.a' found: OK
  >> file 'lib64/libcudnn_engines_precompiled_static.a' found: OK
  >> file 'lib64/libcudnn_engines_runtime_compiled_static.a' found: OK
  >> file 'lib64/libcudnn_graph_static.a' found: OK
  >> file 'lib64/libcudnn_heuristic_static.a' found: OK
  >> file 'lib64/libcudnn_ops_static.a' found: OK
  >> (non-empty) directory 'include' found: OK
  >> (non-empty) directory 'lib64' found: OK
  >> loading modules: cuDNN/9.15.0.57-CUDA-12.9.1...
  >> CUDA sanity check summary report:
  >> Number of CUDA files checked: 50
  >> Number of files missing one or more CUDA Compute Capabilities: 40 (ignored: 0, fails: 40)
  >> Number of files with device code for more CUDA Compute Capabilities than requested: 50
  >> (not running with --cuda-sanity-check-strict, so not considered failures)
  >> Number of files missing PTX code for the highest configured CUDA Compute Capability: 50 (ignored: 0, fails: 50)
  >> You may consider rerunning with --cuda-sanity-check-accept-ptx-as-devcode to accept suitable PTX code instead of device code.
  >> You may consider running with --cuda-sanity-check-accept-missing-ptx to accept binaries missing PTX code for the highest configured CUDA Compute Capability.
  >> See build log for detailed lists of files not passing the CUDA Sanity Check
== ... (took 1 min 26 secs)
== FAILED: Installation ended unsuccessfully: Sanity check failed:
Files missing CUDA device code: 40.
Files missing CUDA PTX code: 50.
Check the build log for the 'CUDA sanity check detailed report' for a full list of files that failed to pass the sanity check. (took 4 mins 34 secs)
```