### PR TITLE
`eessi_archdetect.sh`: Allow for a default vendor fallback for ARM CPUs

### DIFF
--- a/init/eessi_archdetect.sh
+++ b/init/eessi_archdetect.sh
@@ -93,11 +93,11 @@ cpupath(){
     # Identify the best matching CPU architecture from a list of supported specifications for the host CPU
     # Return the path to the installation files in EESSI of the best matching architecture
     local cpu_arch_spec=()
-  
+
     # Identify the host CPU architecture
     local machine_type=${EESSI_MACHINE_TYPE:-$(uname -m)}
     log "DEBUG" "cpupath: Host CPU architecture identified as '$machine_type'"
-  
+
     # Populate list of supported specs for this architecture
     case $machine_type in
         "x86_64") local spec_file="eessi_arch_x86.spec";;
@@ -109,14 +109,28 @@ cpupath(){
     # spec files are located in a subfolder with this script
     local base_dir=$(dirname $(readlink -f $0))
     update_arch_specs "$base_dir/arch_specs/${spec_file}"
-  
+
     # Identify the host CPU vendor
     local cpu_vendor=$(get_cpuinfo "vendor[ _]id")
     if [ "${cpu_vendor}" == "" ]; then
         cpu_vendor=$(get_cpuinfo "cpu[ _]implementer")
     fi
     log "DEBUG" "cpupath: CPU vendor of host system: '$cpu_vendor'"
-  
+    # Construct a list of known cpu vendors
+    local cpu_vendors=()
+    for spec in "${cpu_arch_spec[@]}"; do
+        eval "cols=$spec"
+        cpu_vendors+=("${cols[1]}")
+    done
+    log "DEBUG" "cpupath: Known CPU vendors: ${cpu_vendors[*]}"
+    # For ARM, if CPU vendor is as-yet-unknown fall back to a default ARM vendor 0x41
+    if [ "${machine_type}" == "aarch64" ]; then
+        if [[ " ${cpu_vendors[*]} " != *" $cpu_vendor "* ]]; then
+            log "DEBUG" "cpupath: Unknown ARM CPU vendor '$cpu_vendor', falling back to '0x41'"
+            cpu_vendor="0x41"
+        fi
+    fi
+
     # Identify the host CPU flags or features
     # cpuinfo systems print different line identifiers, eg features, instead of flags
     local cpu_flag_tag;
@@ -132,14 +146,14 @@ cpupath(){
     else
         cpu_flag_tag='flags'
     fi
-  
+
     local cpu_flags=$(get_cpuinfo "$cpu_flag_tag")
     log "DEBUG" "cpupath: CPU flags of host system: '$cpu_flags'"
-  
+
     # Default to generic CPU
     local best_arch_match="$machine_type/generic"
     local all_arch_matches=$best_arch_match
-  
+
     # Iterate over the supported CPU specifications to find the best match for host CPU
     # Order of the specifications matters, the last one to match will be selected
     for arch in "${cpu_arch_spec[@]}"; do
@@ -151,7 +165,7 @@ cpupath(){
                 log "DEBUG" "cpupath: host CPU best match updated to $best_arch_match" 
         fi
     done
-  
+
     if [ "allx" == "${CPUPATH_RESULT}x" ]; then
         log "INFO" "cpupath: all matches for host CPU: $all_arch_matches"
         echo "$all_arch_matches"
@@ -219,4 +233,3 @@ case "$ARGUMENT" in
     "accelpath") accelpath; exit;;
     *) echo "$USAGE"; log "ERROR" "Missing <action> argument (possible actions: 'cpupath', 'accelpath')";;
 esac
-


### PR DESCRIPTION
```bash
$ /cvmfs/software.eessi.io/versions/2025.06/init/eessi_archdetect.sh -d -a cpupath
2026-03-06 11:08:16 [DEBUG] cpupath: Override variable set as ''
2026-03-06 11:08:16 [DEBUG] cpupath: Host CPU architecture identified as 'aarch64'
2026-03-06 11:08:16 [DEBUG] cpupath: CPU vendor of host system: '0x51'
2026-03-06 11:08:16 [DEBUG] cpupath: CPU flags of host system: 'fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm jscvt fcma lrcpc dcpop sha3 sm3 sm4 asimddp sha512 asimdfhm uscat ilrcpc flagm ssbs sb paca pacg dcpodp flagm2 frint i8mm bf16 rng afp rpres'
2026-03-06 11:08:16 [INFO] cpupath: all matches for host CPU: aarch64/generic
aarch64/generic
$ ./init/eessi_archdetect.sh -d -a cpupath
2026-03-06 11:08:30 [DEBUG] cpupath: Override variable set as ''
2026-03-06 11:08:30 [DEBUG] cpupath: Host CPU architecture identified as 'aarch64'
2026-03-06 11:08:30 [DEBUG] cpupath: CPU vendor of host system: '0x51'
2026-03-06 11:08:30 [DEBUG] cpupath: Known CPU vendors: 0x46 ARM 0x41 ARM 0x41 0x41 0x41
2026-03-06 11:08:30 [DEBUG] cpupath: Unknown ARM CPU vendor '0x51', falling back to '0x41'
2026-03-06 11:08:30 [DEBUG] cpupath: CPU flags of host system: 'fp asimd evtstrm aes pmull sha1 sha2 crc32 atomics fphp asimdhp cpuid asimdrdm jscvt fcma lrcpc dcpop sha3 sm3 sm4 asimddp sha512 asimdfhm uscat ilrcpc flagm ssbs sb paca pacg dcpodp flagm2 frint i8mm bf16 rng afp rpres'
2026-03-06 11:08:30 [DEBUG] cpupath: host CPU best match updated to aarch64/neoverse_n1
2026-03-06 11:08:30 [INFO] cpupath: all matches for host CPU: aarch64/neoverse_n1:aarch64/generic
aarch64/neoverse_n1:aarch64/generic
```