### PR TITLE
`EESSI-extend`: Use `flags` as value for `EASYBUILD_SEARCH_PATH_CPP_HEADERS` (to rely on `$CPPFLAGS` in build environment instead of redefining `$C_INCLUDE_PATH` & co)

### DIFF
--- a/EESSI-extend-easybuild.eb
+++ b/EESSI-extend-easybuild.eb
@@ -245,7 +245,7 @@ if mode() == "unload" or mode() == "dependencyCk" or convertToCanonical(easybuil
   if convertToCanonical(eessi_version) > convertToCanonical("2023.06") then
     setenv ("EASYBUILD_PREFER_PYTHON_SEARCH_PATH", "EBPYTHONPREFIXES")
     setenv ("EASYBUILD_MODULE_SEARCH_PATH_HEADERS", "include_paths")
-    setenv ("EASYBUILD_SEARCH_PATH_CPP_HEADERS", "include_paths")
+    setenv ("EASYBUILD_SEARCH_PATH_CPP_HEADERS", "flags")
   end
 end
 


### PR DESCRIPTION
This avoids https://github.com/easybuilders/easybuild-framework/issues/5124 and has no impact on the expected behaviour.

This will unblock https://github.com/EESSI/software-layer/pull/1444 and https://github.com/EESSI/software-layer/pull/1421