### PR TITLE
fix EESSI prefix for complex prompts

### DIFF
--- a/.github/workflows/scripts/test_init_scripts.sh
+++ b/.github/workflows/scripts/test_init_scripts.sh
@@ -154,22 +154,23 @@ for shell in ${SHELLS[@]}; do
 
     # Optional test 11, check if the prompt has been updated
     if [ "$shell" = "bash" ] || [ "$shell" = "ksh" ] || [ "$shell" = "zsh" ] || [ "$shell" = "sh" ]; then
-        # Typically this is a non-interactive shell, so manually unset PS1 and reset to a non-exported variable when testing
-        TEST_EESSI_PS1_UPDATE=$($shell -c "unset PS1 ; PS1='$ ' ; . init/lmod/$shell 2>/dev/null ; echo \"\$PS1\"")
-        TEST_EESSI_NO_PS1_UPDATE=$($shell -c "unset PS1 ; . init/lmod/$shell 2>/dev/null ; echo \"\$PS1\"")
-        pattern="{EESSI/${EESSI_VERSION}} "
-        assert_raises 'echo "$TEST_EESSI_PS1_UPDATE" | grep "$pattern"'
-        assert_raises 'echo "$TEST_EESSI_NO_PS1_UPDATE" | grep "$pattern"' 1
-        # Also check when we explicitly ask for it not to be updated
-        TEST_EESSI_EXPLICIT_NO_PS1_UPDATE=$($shell -c "unset PS1 ; PS1='test> ' ; export EESSI_MODULE_UPDATE_PS1=0 ; . init/lmod/$shell 2>/dev/null ; echo \"\$PS1\"")
-        TEST_EESSI_EXPLICIT_NO_PS1_UPDATE_CALLED_TWICE=$($shell -c "unset PS1 ; PS1='$ ' ; export EESSI_MODULE_UPDATE_PS1=0 ; . init/lmod/$shell 2>/dev/null ; . init/lmod/$shell 2>/dev/null ; echo \"\$PS1\"")
-        assert_raises 'echo "$TEST_EESSI_EXPLICIT_NO_PS1_UPDATE" | grep "$pattern"' 1
-        assert_raises 'echo "$TEST_EESSI_EXPLICIT_NO_PS1_UPDATE_CALLED_TWICE" | grep "$pattern"' 1
-        # Also check complex prompts, and unloading/purging the EESSI module
+        # Let's configure things to use the EESSI module within the PR
         sed 's|export MODULEPATH=.*|export MODULEPATH=init/modules|' init/lmod/sh >init/lmod/sh.test
         ln -srf init/lmod/sh.test init/lmod/bash.test
         ln -srf init/lmod/sh.test init/lmod/ksh.test
         ln -srf init/lmod/sh.test init/lmod/zsh.test
+        # Typically this is a non-interactive shell, so manually unset PS1 and reset to a non-exported variable when testing
+        TEST_EESSI_PS1_UPDATE=$($shell -c "unset PS1 ; PS1='$ ' ; . init/lmod/$shell.test 2>/dev/null ; echo \"\$PS1\"")
+        TEST_EESSI_NO_PS1_UPDATE=$($shell -c "unset PS1 ; . init/lmod/$shell.test 2>/dev/null ; echo \"\$PS1\"")
+        pattern="{EESSI/${EESSI_VERSION}} "
+        assert_raises 'echo "$TEST_EESSI_PS1_UPDATE" | grep "$pattern"'
+        assert_raises 'echo "$TEST_EESSI_NO_PS1_UPDATE" | grep "$pattern"' 1
+        # Also check when we explicitly ask for it not to be updated
+        TEST_EESSI_EXPLICIT_NO_PS1_UPDATE=$($shell -c "unset PS1 ; PS1='test> ' ; export EESSI_MODULE_UPDATE_PS1=0 ; . init/lmod/$shell.test 2>/dev/null ; echo \"\$PS1\"")
+        TEST_EESSI_EXPLICIT_NO_PS1_UPDATE_CALLED_TWICE=$($shell -c "unset PS1 ; PS1='$ ' ; export EESSI_MODULE_UPDATE_PS1=0 ; . init/lmod/$shell.test 2>/dev/null ; . init/lmod/$shell.test 2>/dev/null ; echo \"\$PS1\"")
+        assert_raises 'echo "$TEST_EESSI_EXPLICIT_NO_PS1_UPDATE" | grep "$pattern"' 1
+        assert_raises 'echo "$TEST_EESSI_EXPLICIT_NO_PS1_UPDATE_CALLED_TWICE" | grep "$pattern"' 1
+        # Also check complex prompts, and unloading/purging the EESSI module
         prompt="\$(echo '\['✘) $ "
         promptstr="\[✘ $ "
         updated_promptstr="{EESSI/${EESSI_VERSION}} \[✘ $ "

--- a/.github/workflows/scripts/test_init_scripts.sh
+++ b/.github/workflows/scripts/test_init_scripts.sh
@@ -166,7 +166,7 @@ for shell in ${SHELLS[@]}; do
         assert_raises 'echo "$TEST_EESSI_EXPLICIT_NO_PS1_UPDATE" | grep "$pattern"' 1
         assert_raises 'echo "$TEST_EESSI_EXPLICIT_NO_PS1_UPDATE_CALLED_TWICE" | grep "$pattern"' 1
         # Also check complex prompts, and unloading/purging the EESSI module
-        sed 's/__EESSI_VERSION_DEFAULT__/2023.06/' init/lmod/sh >init/lmod/sh.test
+        sed "s/__EESSI_VERSION_DEFAULT__/${EESSI_VERSION}/" init/lmod/sh >init/lmod/sh.test
         ln -sr init/lmod/sh.test init/lmod/bash.test
         ln -sr init/lmod/sh.test init/lmod/ksh.test
         ln -sr init/lmod/sh.test init/lmod/zsh.test

--- a/.github/workflows/scripts/test_init_scripts.sh
+++ b/.github/workflows/scripts/test_init_scripts.sh
@@ -171,8 +171,8 @@ for shell in ${SHELLS[@]}; do
         updated_promptstr="{EESSI/${EESSI_VERSION}} \[✘ $ "
         TEST_EESSI_PS1_UPDATE=$($shell -c "unset PS1 ; PS1=\"$prompt\" ; . init/lmod/$shell >/dev/null 2>&1 ; echo \"\$PS1\"")
         TEST_EESSI_PS1_REVERT=$($shell -c "unset PS1 ; PS1=\"$prompt\" ; . init/lmod/$shell >/dev/null 2>&1 ; module purge; echo \"\$PS1\"")
-        assert "$TEST_EESSI_PS1_UPDATE" "$updated_promptstr"
-        assert "$TEST_EESSI_PS1_REVERT" "$promptstr"
+        assert 'echo "$TEST_EESSI_PS1_UPDATE"' "$updated_promptstr"
+        assert 'echo "$TEST_EESSI_PS1_REVERT"' "$promptstr"
     fi
 
     # End Test Suite

--- a/.github/workflows/scripts/test_init_scripts.sh
+++ b/.github/workflows/scripts/test_init_scripts.sh
@@ -165,6 +165,13 @@ for shell in ${SHELLS[@]}; do
         TEST_EESSI_EXPLICIT_NO_PS1_UPDATE_CALLED_TWICE=$($shell -c "unset PS1 ; PS1='$ ' ; export EESSI_MODULE_UPDATE_PS1=0 ; . init/lmod/$shell 2>/dev/null ; . init/lmod/$shell 2>/dev/null ; echo \"\$PS1\"")
         assert_raises 'echo "$TEST_EESSI_EXPLICIT_NO_PS1_UPDATE" | grep "$pattern"' 1
         assert_raises 'echo "$TEST_EESSI_EXPLICIT_NO_PS1_UPDATE_CALLED_TWICE" | grep "$pattern"' 1
+        # Also check complex prompts, and unloading/purging the EESSI module
+        prompt="\$(echo '\['✘) $ "
+        updated_prompt="{EESSI/${EESSI_VERSION}} \[✘ $ "
+        TEST_EESSI_PS1_UPDATE=$($shell -c "unset PS1 ; PS1=\"$prompt\" ; . init/lmod/$shell >/dev/null 2>&1 ; echo \"\$PS1\"")
+        TEST_EESSI_NO_PS1_UPDATE=$($shell -c "unset PS1 ; PS1=\"$prompt\" ; . init/lmod/$shell >/dev/null 2>&1 ; module purge; echo \"\$PS1\"")
+        assert "$TEST_EESSI_PS1_UPDATE" "$updated_prompt"
+        assert "$TEST_EESSI_NO_PS1_UPDATE" "$prompt"
     fi
 
     # End Test Suite

--- a/.github/workflows/scripts/test_init_scripts.sh
+++ b/.github/workflows/scripts/test_init_scripts.sh
@@ -173,8 +173,8 @@ for shell in ${SHELLS[@]}; do
         prompt="\$(echo '\['✘) $ "
         promptstr="\[✘ $ "
         updated_promptstr="{EESSI/${EESSI_VERSION}} \[✘ $ "
-        TEST_EESSI_PS1_UPDATE=$($shell -c "unset PS1 ; PS1=\"$prompt\" ; export EESSI_CVMFS_REPO=$PWD ; export LMOD_IGNORE_CACHE=1 ; . init/lmod/$shell.test >/dev/null ; echo \"\$PS1\"")
-        TEST_EESSI_PS1_REVERT=$($shell -c "unset PS1 ; PS1=\"$prompt\" ; export EESSI_CVMFS_REPO=$PWD ; export LMOD_IGNORE_CACHE=1 ; . init/lmod/$shell.test >/dev/null ; module purge; echo \"\$PS1\"")
+        TEST_EESSI_PS1_UPDATE=$($shell -c "unset PS1 ; PS1=\"$prompt\" ; . init/lmod/$shell.test >/dev/null ; echo \"\$PS1\"")
+        TEST_EESSI_PS1_REVERT=$($shell -c "unset PS1 ; PS1=\"$prompt\" ; . init/lmod/$shell.test >/dev/null ; module purge; echo \"\$PS1\"")
         assert 'echo "$TEST_EESSI_PS1_UPDATE"' "$updated_promptstr"
         assert 'echo "$TEST_EESSI_PS1_REVERT"' "$promptstr"
     fi

--- a/.github/workflows/scripts/test_init_scripts.sh
+++ b/.github/workflows/scripts/test_init_scripts.sh
@@ -167,11 +167,12 @@ for shell in ${SHELLS[@]}; do
         assert_raises 'echo "$TEST_EESSI_EXPLICIT_NO_PS1_UPDATE_CALLED_TWICE" | grep "$pattern"' 1
         # Also check complex prompts, and unloading/purging the EESSI module
         prompt="\$(echo '\['✘) $ "
-        updated_prompt="{EESSI/${EESSI_VERSION}} \[✘ $ "
+        promptstr="\[✘ $ "
+        updated_promptstr="{EESSI/${EESSI_VERSION}} \[✘ $ "
         TEST_EESSI_PS1_UPDATE=$($shell -c "unset PS1 ; PS1=\"$prompt\" ; . init/lmod/$shell >/dev/null 2>&1 ; echo \"\$PS1\"")
-        TEST_EESSI_NO_PS1_UPDATE=$($shell -c "unset PS1 ; PS1=\"$prompt\" ; . init/lmod/$shell >/dev/null 2>&1 ; module purge; echo \"\$PS1\"")
-        assert "$TEST_EESSI_PS1_UPDATE" "$updated_prompt"
-        assert "$TEST_EESSI_NO_PS1_UPDATE" "$prompt"
+        TEST_EESSI_PS1_REVERT=$($shell -c "unset PS1 ; PS1=\"$prompt\" ; . init/lmod/$shell >/dev/null 2>&1 ; module purge; echo \"\$PS1\"")
+        assert "$TEST_EESSI_PS1_UPDATE" "$updated_promptstr"
+        assert "$TEST_EESSI_PS1_REVERT" "$promptstr"
     fi
 
     # End Test Suite

--- a/.github/workflows/scripts/test_init_scripts.sh
+++ b/.github/workflows/scripts/test_init_scripts.sh
@@ -166,11 +166,15 @@ for shell in ${SHELLS[@]}; do
         assert_raises 'echo "$TEST_EESSI_EXPLICIT_NO_PS1_UPDATE" | grep "$pattern"' 1
         assert_raises 'echo "$TEST_EESSI_EXPLICIT_NO_PS1_UPDATE_CALLED_TWICE" | grep "$pattern"' 1
         # Also check complex prompts, and unloading/purging the EESSI module
+        sed 's/__EESSI_VERSION_DEFAULT__/2023.06/' init/lmod/sh >init/lmod/sh.test
+        ln -sr init/lmod/sh.test init/lmod/bash.test
+        ln -sr init/lmod/sh.test init/lmod/ksh.test
+        ln -sr init/lmod/sh.test init/lmod/zsh.test
         prompt="\$(echo '\['✘) $ "
         promptstr="\[✘ $ "
         updated_promptstr="{EESSI/${EESSI_VERSION}} \[✘ $ "
-        TEST_EESSI_PS1_UPDATE=$($shell -c "unset PS1 ; PS1=\"$prompt\" ; export EESSI_CVMFS_REPO=$PWD ; export LMOD_IGNORE_CACHE=1 ; . init/lmod/$shell >/dev/null 2>&1 ; echo \"\$PS1\"")
-        TEST_EESSI_PS1_REVERT=$($shell -c "unset PS1 ; PS1=\"$prompt\" ; export EESSI_CVMFS_REPO=$PWD ; export LMOD_IGNORE_CACHE=1 ; . init/lmod/$shell >/dev/null 2>&1 ; module purge; echo \"\$PS1\"")
+        TEST_EESSI_PS1_UPDATE=$($shell -c "unset PS1 ; PS1=\"$prompt\" ; export EESSI_CVMFS_REPO=$PWD ; . init/lmod/$shell.test >/dev/null 2>&1 ; echo \"\$PS1\"")
+        TEST_EESSI_PS1_REVERT=$($shell -c "unset PS1 ; PS1=\"$prompt\" ; export EESSI_CVMFS_REPO=$PWD ; . init/lmod/$shell.test >/dev/null 2>&1 ; module purge; echo \"\$PS1\"")
         assert 'echo "$TEST_EESSI_PS1_UPDATE"' "$updated_promptstr"
         assert 'echo "$TEST_EESSI_PS1_REVERT"' "$promptstr"
     fi

--- a/.github/workflows/scripts/test_init_scripts.sh
+++ b/.github/workflows/scripts/test_init_scripts.sh
@@ -169,8 +169,8 @@ for shell in ${SHELLS[@]}; do
         prompt="\$(echo '\['✘) $ "
         promptstr="\[✘ $ "
         updated_promptstr="{EESSI/${EESSI_VERSION}} \[✘ $ "
-        TEST_EESSI_PS1_UPDATE=$($shell -c "unset PS1 ; PS1=\"$prompt\" ; . init/lmod/$shell >/dev/null 2>&1 ; echo \"\$PS1\"")
-        TEST_EESSI_PS1_REVERT=$($shell -c "unset PS1 ; PS1=\"$prompt\" ; . init/lmod/$shell >/dev/null 2>&1 ; module purge; echo \"\$PS1\"")
+        TEST_EESSI_PS1_UPDATE=$($shell -c "unset PS1 ; PS1=\"$prompt\" ; EESSI_CVMFS_REPO=$PWD . init/lmod/$shell >/dev/null 2>&1 ; echo \"\$PS1\"")
+        TEST_EESSI_PS1_REVERT=$($shell -c "unset PS1 ; PS1=\"$prompt\" ; EESSI_CVMFS_REPO=$PWD . init/lmod/$shell >/dev/null 2>&1 ; module purge; echo \"\$PS1\"")
         assert 'echo "$TEST_EESSI_PS1_UPDATE"' "$updated_promptstr"
         assert 'echo "$TEST_EESSI_PS1_REVERT"' "$promptstr"
     fi

--- a/.github/workflows/scripts/test_init_scripts.sh
+++ b/.github/workflows/scripts/test_init_scripts.sh
@@ -166,10 +166,10 @@ for shell in ${SHELLS[@]}; do
         assert_raises 'echo "$TEST_EESSI_EXPLICIT_NO_PS1_UPDATE" | grep "$pattern"' 1
         assert_raises 'echo "$TEST_EESSI_EXPLICIT_NO_PS1_UPDATE_CALLED_TWICE" | grep "$pattern"' 1
         # Also check complex prompts, and unloading/purging the EESSI module
-        sed "s/__EESSI_VERSION_DEFAULT__/${EESSI_VERSION}/" init/lmod/sh >init/lmod/sh.test
-        ln -sr init/lmod/sh.test init/lmod/bash.test
-        ln -sr init/lmod/sh.test init/lmod/ksh.test
-        ln -sr init/lmod/sh.test init/lmod/zsh.test
+        sed 's|export MODULEPATH=.*|export MODULEPATH=init/modules|' init/lmod/sh >init/lmod/sh.test
+        ln -srf init/lmod/sh.test init/lmod/bash.test
+        ln -srf init/lmod/sh.test init/lmod/ksh.test
+        ln -srf init/lmod/sh.test init/lmod/zsh.test
         prompt="\$(echo '\['✘) $ "
         promptstr="\[✘ $ "
         updated_promptstr="{EESSI/${EESSI_VERSION}} \[✘ $ "

--- a/.github/workflows/scripts/test_init_scripts.sh
+++ b/.github/workflows/scripts/test_init_scripts.sh
@@ -173,8 +173,8 @@ for shell in ${SHELLS[@]}; do
         prompt="\$(echo '\['✘) $ "
         promptstr="\[✘ $ "
         updated_promptstr="{EESSI/${EESSI_VERSION}} \[✘ $ "
-        TEST_EESSI_PS1_UPDATE=$($shell -c "unset PS1 ; PS1=\"$prompt\" ; export EESSI_CVMFS_REPO=$PWD ; . init/lmod/$shell.test >/dev/null 2>&1 ; echo \"\$PS1\"")
-        TEST_EESSI_PS1_REVERT=$($shell -c "unset PS1 ; PS1=\"$prompt\" ; export EESSI_CVMFS_REPO=$PWD ; . init/lmod/$shell.test >/dev/null 2>&1 ; module purge; echo \"\$PS1\"")
+        TEST_EESSI_PS1_UPDATE=$($shell -c "unset PS1 ; PS1=\"$prompt\" ; export EESSI_CVMFS_REPO=$PWD ; export LMOD_IGNORE_CACHE=1 ; . init/lmod/$shell.test >/dev/null ; echo \"\$PS1\"")
+        TEST_EESSI_PS1_REVERT=$($shell -c "unset PS1 ; PS1=\"$prompt\" ; export EESSI_CVMFS_REPO=$PWD ; export LMOD_IGNORE_CACHE=1 ; . init/lmod/$shell.test >/dev/null ; module purge; echo \"\$PS1\"")
         assert 'echo "$TEST_EESSI_PS1_UPDATE"' "$updated_promptstr"
         assert 'echo "$TEST_EESSI_PS1_REVERT"' "$promptstr"
     fi

--- a/.github/workflows/scripts/test_init_scripts.sh
+++ b/.github/workflows/scripts/test_init_scripts.sh
@@ -169,8 +169,8 @@ for shell in ${SHELLS[@]}; do
         prompt="\$(echo '\['✘) $ "
         promptstr="\[✘ $ "
         updated_promptstr="{EESSI/${EESSI_VERSION}} \[✘ $ "
-        TEST_EESSI_PS1_UPDATE=$($shell -c "unset PS1 ; PS1=\"$prompt\" ; EESSI_CVMFS_REPO=$PWD . init/lmod/$shell >/dev/null 2>&1 ; echo \"\$PS1\"")
-        TEST_EESSI_PS1_REVERT=$($shell -c "unset PS1 ; PS1=\"$prompt\" ; EESSI_CVMFS_REPO=$PWD . init/lmod/$shell >/dev/null 2>&1 ; module purge; echo \"\$PS1\"")
+        TEST_EESSI_PS1_UPDATE=$($shell -c "unset PS1 ; PS1=\"$prompt\" ; export EESSI_CVMFS_REPO=$PWD ; export LMOD_IGNORE_CACHE=1 ; . init/lmod/$shell >/dev/null 2>&1 ; echo \"\$PS1\"")
+        TEST_EESSI_PS1_REVERT=$($shell -c "unset PS1 ; PS1=\"$prompt\" ; export EESSI_CVMFS_REPO=$PWD ; export LMOD_IGNORE_CACHE=1 ; . init/lmod/$shell >/dev/null 2>&1 ; module purge; echo \"\$PS1\"")
         assert 'echo "$TEST_EESSI_PS1_UPDATE"' "$updated_promptstr"
         assert 'echo "$TEST_EESSI_PS1_REVERT"' "$promptstr"
     fi

--- a/EESSI-install-software.sh
+++ b/EESSI-install-software.sh
@@ -414,7 +414,7 @@ else
                 if [ ${ec} -ne 0 ]; then
                     eb_last_log=$(eb --last-log | grep ^/.*\.log)
                     # copy to current working directory if file exhists
-		    if [ -e ${eb_last_log} ]; then
+                    if [ -e ${eb_last_log} ]; then
                         cp -a ${eb_last_log} .
                         echo "Last EasyBuild log file copied from ${eb_last_log} to ${PWD}"
                         # copy to build logs dir (with context added)

--- a/EESSI-install-software.sh
+++ b/EESSI-install-software.sh
@@ -412,12 +412,14 @@ else
 
                 # copy EasyBuild log file if EasyBuild exited with an error
                 if [ ${ec} -ne 0 ]; then
-                    eb_last_log=$(unset EB_VERBOSE; eb --last-log)
+	            eb_hooks=$EASYBUILD_HOOKS
+                    eb_last_log=$(unset EB_VERBOSE; unset EASYBUILD_HOOKS; eb --last-log)
                     # copy to current working directory
                     cp -a ${eb_last_log} .
                     echo "Last EasyBuild log file copied from ${eb_last_log} to ${PWD}"
                     # copy to build logs dir (with context added)
                     copy_build_log "${eb_last_log}" "${build_logs_dir}"
+		    export EASYBUILD_HOOKS=$eb_hooks
                 fi
 
                 $TOPDIR/check_missing_installations.sh ${easystack_file} ${pr_diff}

--- a/EESSI-install-software.sh
+++ b/EESSI-install-software.sh
@@ -414,7 +414,7 @@ else
                 if [ ${ec} -ne 0 ]; then
                     eb_last_log=$(eb --last-log | grep ^/.*\.log)
                     # copy to current working directory if file exhists
-                    if [ -e ${eb_last_log} ]; then
+                    if [ -f ${eb_last_log} ]; then
                         cp -a ${eb_last_log} .
                         echo "Last EasyBuild log file copied from ${eb_last_log} to ${PWD}"
                         # copy to build logs dir (with context added)

--- a/EESSI-install-software.sh
+++ b/EESSI-install-software.sh
@@ -412,7 +412,7 @@ else
 
                 # copy EasyBuild log file if EasyBuild exited with an error
                 if [ ${ec} -ne 0 ]; then
-                    eb_last_log=$(eb --last-log | grep | grep -vE "==|>>")
+                    eb_last_log=$(eb --last-log | grep -vE "==|>>")
                     # copy to current working directory
                     cp -a ${eb_last_log} .
                     echo "Last EasyBuild log file copied from ${eb_last_log} to ${PWD}"

--- a/EESSI-install-software.sh
+++ b/EESSI-install-software.sh
@@ -413,11 +413,15 @@ else
                 # copy EasyBuild log file if EasyBuild exited with an error
                 if [ ${ec} -ne 0 ]; then
                     eb_last_log=$(eb --last-log | grep ^/.*\.log)
-                    # copy to current working directory
-                    cp -a ${eb_last_log} .
-                    echo "Last EasyBuild log file copied from ${eb_last_log} to ${PWD}"
-                    # copy to build logs dir (with context added)
-                    copy_build_log "${eb_last_log}" "${build_logs_dir}"
+                    # copy to current working directory if file exhists
+		    if [ -e ${eb_last_log} ]; then
+                        cp -a ${eb_last_log} .
+                        echo "Last EasyBuild log file copied from ${eb_last_log} to ${PWD}"
+                        # copy to build logs dir (with context added)
+                        copy_build_log "${eb_last_log}" "${build_logs_dir}"
+                    else
+                        fatal_error "Could not copy EasyBuild log file because ${eb_last_log} does not exhist"
+                    fi
                 fi
 
                 $TOPDIR/check_missing_installations.sh ${easystack_file} ${pr_diff}

--- a/EESSI-install-software.sh
+++ b/EESSI-install-software.sh
@@ -412,14 +412,12 @@ else
 
                 # copy EasyBuild log file if EasyBuild exited with an error
                 if [ ${ec} -ne 0 ]; then
-	            eb_hooks=$EASYBUILD_HOOKS
-                    eb_last_log=$(unset EB_VERBOSE; unset EASYBUILD_HOOKS; eb --last-log)
+                    eb_last_log=$(eb --last-log | grep | grep -vE "==|>>")
                     # copy to current working directory
                     cp -a ${eb_last_log} .
                     echo "Last EasyBuild log file copied from ${eb_last_log} to ${PWD}"
                     # copy to build logs dir (with context added)
                     copy_build_log "${eb_last_log}" "${build_logs_dir}"
-		    export EASYBUILD_HOOKS=$eb_hooks
                 fi
 
                 $TOPDIR/check_missing_installations.sh ${easystack_file} ${pr_diff}

--- a/EESSI-install-software.sh
+++ b/EESSI-install-software.sh
@@ -420,7 +420,7 @@ else
                         # copy to build logs dir (with context added)
                         copy_build_log "${eb_last_log}" "${build_logs_dir}"
                     else
-                        fatal_error "Could not copy EasyBuild log file because ${eb_last_log} does not exhist"
+                        fatal_error "Could not copy EasyBuild log file because ${eb_last_log} does not exist"
                     fi
                 fi
 

--- a/EESSI-install-software.sh
+++ b/EESSI-install-software.sh
@@ -412,7 +412,7 @@ else
 
                 # copy EasyBuild log file if EasyBuild exited with an error
                 if [ ${ec} -ne 0 ]; then
-                    eb_last_log=$(eb --last-log | grep -vE "==|>>")
+                    eb_last_log=$(eb --last-log | grep ^/.*\.log)
                     # copy to current working directory
                     cp -a ${eb_last_log} .
                     echo "Last EasyBuild log file copied from ${eb_last_log} to ${PWD}"

--- a/init/modules/EESSI/2023.06.lua
+++ b/init/modules/EESSI/2023.06.lua
@@ -225,10 +225,10 @@ if os.getenv("EESSI_MODULE_UPDATE_PS1") then
         local prefix = "{EESSI/" .. eessi_version .. "} "
         if mode() == "load" then
             -- Prepend prefix to PS1 without evaluating its contents
-            execute{cmd="PS1='" .. prefix .. "'\"$PS1\"", modeA={"load"}}
+            execute{cmd="PS1=\"" .. prefix .. "$PS1\"", modeA={"load"}}
         elseif mode() == "unload" then
             -- Strip the prefix from beginning of PS1
-            execute{cmd="PS1=\"${PS1#'" .. prefix .. "'}\"", modeA={"unload"}}
+            execute{cmd="PS1=\"${PS1#\"" .. prefix .. "\"}\"", modeA={"unload"}}
         end
     end
 end

--- a/init/modules/EESSI/2023.06.lua
+++ b/init/modules/EESSI/2023.06.lua
@@ -240,11 +240,13 @@ if os.getenv("EESSI_MODULE_STICKY") then
     load_message = load_message .. " (requires '--force' option to unload or purge)"
 end
 
--- set CURL_CA_BUNDLE on RHEL-based systems
+-- set CURL_CA_BUNDLE and friends on RHEL-based systems
 ca_bundle_file_rhel = "/etc/pki/tls/certs/ca-bundle.crt"
 if isFile(ca_bundle_file_rhel) then
     pushenv("CURL_CA_BUNDLE", ca_bundle_file_rhel)
-    eessiDebug("Setting CURL_CA_BUNDLE to " .. ca_bundle_file_rhel)
+    pushenv("REQUESTS_CA_BUNDLE", ca_bundle_file_rhel)
+    pushenv("SSL_CERT_FILE", ca_bundle_file_rhel)
+    eessiDebug("Setting CURL_CA_BUNDLE,REQUESTS_CA_BUNDLE,SSL_CERT_FILE to " .. ca_bundle_file_rhel)
 end
 
 if mode() == "load" then

--- a/init/modules/EESSI/2023.06.lua
+++ b/init/modules/EESSI/2023.06.lua
@@ -222,6 +222,7 @@ local quiet_load = false
 if os.getenv("EESSI_MODULE_UPDATE_PS1") then
     local prompt = os.getenv("PS1")
     if prompt then
+        local prefix = "{EESSI/" .. eessi_version .. "} "
         if mode() == "load" then
             -- Prepend prefix to PS1 without evaluating its contents
             execute{cmd="PS1='" .. prefix .. "'\"$PS1\"", modeA={"load"}}

--- a/init/modules/EESSI/2023.06.lua
+++ b/init/modules/EESSI/2023.06.lua
@@ -222,7 +222,13 @@ local quiet_load = false
 if os.getenv("EESSI_MODULE_UPDATE_PS1") then
     local prompt = os.getenv("PS1")
     if prompt then
-        pushenv("PS1", "{EESSI/" .. eessi_version .. "} " .. prompt)
+        if mode() == "load" then
+            -- Prepend prefix to PS1 without evaluating its contents
+            execute{cmd="PS1='" .. prefix .. "'\"$PS1\"", modeA={"load"}}
+        elseif mode() == "unload" then
+            -- Strip the prefix from beginning of PS1
+            execute{cmd="PS1=\"${PS1#'" .. prefix .. "'}\"", modeA={"unload"}}
+        end
     end
 end
 


### PR DESCRIPTION
my prompt looks like this:
```bash
$(if [ $? != 0 ]; then echo '\[\e[0;31m\]' '\[\e[0m\]'; else echo '\[\e[0;32m\]' '\[\e[0m\]'; fi)\[\033[33m\][$(date '+%H:%M')]\[\033[00m\] \u@\h \[\033[01;34m\]$(fixpathvsc)\[\033[00m\] \$ $(__git_ps1 "(%s) ")$(test $(id -gn) != "vsc10009" && echo "($(id -gn)) ")
```
before this PR, it results in an error and a hanging shell after unloading the EESSI module:
```bash
 [20:21] vsc10009@login1 $VSC_HOME $ source /cvmfs/software.eessi.io/versions/2025.06/init/lmod/bash
Modules purged before initialising EESSI
Module for EESSI/2025.06 loaded successfully
EESSI has selected x86_64/intel/skylake_avx512 as the compatible CPU target for EESSI/2025.06
EESSI did not identify an accelerator on the system
(for debug information when loading the EESSI module, set the environment variable EESSI_MODULE_DEBUG_INIT)
{EESSI/2025.06}  [20:21] vsc10009@login1 $VSC_HOME $ ml unload EESSI/2025.06                                                                                                                      
-bash: command substitution: line 3: unexpected EOF while looking for matching `"'                                                                                                                 
-bash: command substitution: line 4: syntax error: unexpected end of file
-bash: command substitution: line 1: unexpected EOF while looking for matching `)'
-bash: command substitution: line 2: syntax error: unexpected end of file
```