### PR TITLE
Change 120f to 120 for cuda 12.8.0

### DIFF
--- a/easystacks/software.eessi.io/2025.06/accel/nvidia/eessi-2025.06-eb-5.3.0-2025a.yml
+++ b/easystacks/software.eessi.io/2025.06/accel/nvidia/eessi-2025.06-eb-5.3.0-2025a.yml
@@ -1,0 +1,7 @@
+easyconfigs:
+  - UCX-CUDA-1.18.0-GCCcore-14.2.0-CUDA-12.8.0.eb:
+  - NCCL-2.27.7-GCCcore-14.2.0-CUDA-12.8.0.eb:
+      options:
+        cuda-sanity-check-accept-missing-ptx: True
+  - UCC-CUDA-1.3.0-GCCcore-14.2.0-CUDA-12.8.0.eb:
+  - OSU-Micro-Benchmarks-7.5-gompi-2025a-CUDA-12.8.0.eb:

--- a/easystacks/software.eessi.io/2025.06/accel/nvidia/eessi-2025.06-eb-5.3.0-2025a.yml
+++ b/easystacks/software.eessi.io/2025.06/accel/nvidia/eessi-2025.06-eb-5.3.0-2025a.yml
@@ -1,7 +1,0 @@
-easyconfigs:
-  - UCX-CUDA-1.18.0-GCCcore-14.2.0-CUDA-12.8.0.eb:
-  - NCCL-2.27.7-GCCcore-14.2.0-CUDA-12.8.0.eb:
-      options:
-        cuda-sanity-check-accept-missing-ptx: True
-  - UCC-CUDA-1.3.0-GCCcore-14.2.0-CUDA-12.8.0.eb:
-  - OSU-Micro-Benchmarks-7.5-gompi-2025a-CUDA-12.8.0.eb:

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -449,6 +449,9 @@ def pre_prepare_hook(self, *args, **kwargs):
     # Always trigger this, regardless of ec.name
     pre_prepare_hook_unsupported_modules(self, *args, **kwargs)
 
+    # Always trigger this, regardless of ec.name
+    pre_prepare_hook_cuda_dependant(self, *args, **kwargs)
+
 
 def post_prepare_hook_gcc_prefixed_ld_rpath_wrapper(self, *args, **kwargs):
     """
@@ -908,6 +911,20 @@ def post_easyblock_hook_copy_easybuild_subdir(self, *args, **kwargs):
     app_easybuild_dir = os.path.join(self.installdir, config.log_path(ec=self.cfg))
     app_reprod_dir = os.path.join(stack_reprod_dir, self.install_subdir, now_utc_timestamp, 'easybuild')
     copy_dir(app_easybuild_dir, app_reprod_dir)
+
+
+def pre_prepare_hook_cuda_dependant(self, *args, **kwargs):
+    """
+    CUDA 12.8.0 doesn't support the 12.0f target, only 12.0. This hook converts any CC 12.0f into 12.0
+    if the current package depends on CUDA.
+    """
+
+    cudaver = get_dependency_software_version("CUDA", ec=self.cfg, check_deps=True, check_builddeps=True)
+    if cudaver:
+        cuda_cc = build_option('cuda_compute_capabilities')
+        if cuda_cc and '12.0f' in cuda_cc:
+            updated_cuda_cc = [v.replace('12.0f', '12.0') for v in cuda_cc]
+            update_build_option('cuda_compute_capabilities', updated_cuda_cc)
 
 
 def pre_prepare_hook_cudnn(self, *args, **kwargs):


### PR DESCRIPTION
Fixes

```
nvcc fatal   : Unsupported gpu architecture 'compute_120f'
```

Errors for the `120f` target and CUDA toolkit 12.8.0.