### PR TITLE
also change 10.0f to 10.0 for CUDA 12.8.0

### DIFF
--- a/easystacks/software.eessi.io/2025.06/accel/nvidia/eessi-2025.06-eb-5.3.0.yml
+++ b/easystacks/software.eessi.io/2025.06/accel/nvidia/eessi-2025.06-eb-5.3.0.yml
@@ -1,4 +1,0 @@
-easyconfigs:
-  - NCCL-2.27.7-GCCcore-14.2.0-CUDA-12.8.0.eb:
-      options:
-        cuda-sanity-check-accept-missing-ptx: True

--- a/easystacks/software.eessi.io/2025.06/accel/nvidia/eessi-2025.06-eb-5.3.0.yml
+++ b/easystacks/software.eessi.io/2025.06/accel/nvidia/eessi-2025.06-eb-5.3.0.yml
@@ -1,0 +1,4 @@
+easyconfigs:
+  - NCCL-2.27.7-GCCcore-14.2.0-CUDA-12.8.0.eb:
+      options:
+        cuda-sanity-check-accept-missing-ptx: True

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -915,15 +915,15 @@ def post_easyblock_hook_copy_easybuild_subdir(self, *args, **kwargs):
 
 def pre_prepare_hook_cuda_dependant(self, *args, **kwargs):
     """
-    CUDA 12.8.0 doesn't support the 12.0f target, only 12.0. This hook converts any CC 12.0f into 12.0
-    if the current package depends on CUDA.
+    CUDA 12.8.0 doesn't support the 10.0f and 12.0f targets, only 10.0 and 12.0. This hook converts
+    any CC 10.0f / 12.0f into 10.0 / 12.0 if the current package depends on CUDA.
     """
 
     cudaver = get_dependency_software_version("CUDA", ec=self.cfg, check_deps=True, check_builddeps=True)
-    if cudaver:
+    if cudaver and cudaver == '12.8.0':
         cuda_cc = build_option('cuda_compute_capabilities')
-        if cuda_cc and '12.0f' in cuda_cc:
-            updated_cuda_cc = [v.replace('12.0f', '12.0') for v in cuda_cc]
+        if cuda_cc and ('10.0f' in cuda_cc or '12.0f' in cuda_cc):
+            updated_cuda_cc = [v.replace('.0f', '.0') if v in ['10.0f', '12.0f'] else v for v in cuda_cc]
             update_build_option('cuda_compute_capabilities', updated_cuda_cc)
 
 


### PR DESCRIPTION
Follow-up for https://github.com/EESSI/software-layer-scripts/pull/200, turned out it was required to do this for 10.0f as well, see https://github.com/EESSI/software-layer/pull/1462#issuecomment-4286234110.

Also fixes a bug, as there was no CUDA version check in the hook. It now specifically checks for CUDA 12.8.0, the issue doesn't affect 12.9.1.