### PR TITLE
Allow to override AMD GPU accelerator architectures

### DIFF
--- a/init/eessi_archdetect.sh
+++ b/init/eessi_archdetect.sh
@@ -179,13 +179,14 @@ accelpath() {
     # If EESSI_ACCELERATOR_TARGET_OVERRIDE is set, use it
     log "DEBUG" "accelpath: Override variable set as '$EESSI_ACCELERATOR_TARGET_OVERRIDE' "
     if [ ! -z $EESSI_ACCELERATOR_TARGET_OVERRIDE ]; then
-        if [[ "$EESSI_ACCELERATOR_TARGET_OVERRIDE" =~ ^accel/nvidia/cc[0-9]+$ ]]; then
-            echo ${EESSI_ACCELERATOR_TARGET_OVERRIDE}
+        # Regex that allows both NVIDIA and AMD overrides
+        if [[ "$EESSI_ACCELERATOR_TARGET_OVERRIDE" =~ ^accel/(nvidia/cc[0-9]+|amd/gfx[0-9a-f]+)$ ]]; then
+            echo "$EESSI_ACCELERATOR_TARGET_OVERRIDE"
             return 0
         else
-            log "ERROR" "Value of \$EESSI_ACCELERATOR_TARGET_OVERRIDE should match 'accel/nvidia/cc[0-9]+', but it does not: '$EESSI_ACCELERATOR_TARGET_OVERRIDE'"
+            log "ERROR" "Value of \$EESSI_ACCELERATOR_TARGET_OVERRIDE should match 'accel/nvidia/cc[0-9]+' or 'accel/amd/gfx[0-9a-f]+', but it does not: '$EESSI_ACCELERATOR_TARGET_OVERRIDE'"
+            return 1
         fi
-        return 0
     fi
 
     # check for NVIDIA GPUs via nvidia-smi command


### PR DESCRIPTION
This PR adds support to allow `EESSI_ACCELERATOR_TARGET_OVERRIDE` with AMD GPUs. We don't want external users to start using this stack yet, it's really there for our own experimentation. We can add the final support in archdetect to automatically pick up on AMD GPUs when we are convinced the installations in these prefixes _actually_ work (this final support is added in https://github.com/EESSI/software-layer-scripts/pull/205)