### PR TITLE
Make AMD GPU builds use the correct installdir

### DIFF
--- a/EESSI-extend-easybuild.eb
+++ b/EESSI-extend-easybuild.eb
@@ -134,7 +134,7 @@ if eessi_cvmfs_install then
   end
   easybuild_installpath = os.getenv("EESSI_SOFTWARE_PATH")
   -- enforce accelerator subdirectory usage for CVMFS installs (only if an accelerator install is requested)
-  if (eessi_accelerator_target ~= nil) and (cuda_compute_capability ~= nil) and (os.getenv("EESSI_ACCELERATOR_INSTALL") ~= nil) then
+  if (eessi_accelerator_target ~= nil) and (cuda_compute_capability ~= nil or amd_compute_capability ~= nil) and (os.getenv("EESSI_ACCELERATOR_INSTALL") ~= nil) then
       easybuild_installpath = pathJoin(easybuild_installpath, eessi_accelerator_target)
   end
 elseif eessi_site_install then


### PR DESCRIPTION
Account for possibility that we have an AMD instead of NVIDIA accelerator, and in that case ALSO define the installpath including the accelerator subdir.

Proven to work in https://github.com/EESSI/software-layer-scripts/pull/216#issuecomment-4300204362 (build itself failed because another patch was missing that was deployed in #217 , but the point is that it shows the right installpath, including the `accel/amd/gfx90a`)
```
== building and installing ROCm-LLVM/19.0.0-GCCcore-14.2.0-ROCm-6.4.1...
  >> installation prefix:
/cvmfs/software.eessi.io/versions/2025.06/software/linux/x86_64/amd/zen3/accel/a
md/gfx90a/software/ROCm-LLVM/19.0.0-GCCcore-14.2.0-ROCm-6.4.1
== fetching files and verifying checksums...
== Running pre-fetch hook...
== ... (took < 1 sec)
== FAILED: Installation ended unsuccessfully: It seems you are trying to install
a CPU-only package ROCm-LLVM into accelerator location
/cvmfs/software.eessi.io/versions/2025.06/software/linux/x86_64/amd/zen3/accel/a
md/gfx90a/software/ROCm-LLVM/19.0.0-GCCcore-14.2.0-ROCm-6.4.1. If this is a
dependency of the package you are really interested in you will 
```