### PR TITLE
Add libinput as dependency for Qt6 for GCCcore/14.3.0+

### DIFF
--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -676,7 +676,7 @@ def parse_hook_qt6_libinput(ec, eprefix):
                             f"No libinput dependency found for {ec.name} {ec.version}, please update relevant Qt6 hook"
                         )
     else:
-        raise EasyBuildError("Qt6-specific hook triggered for non-maturin easyconfig?!")
+        raise EasyBuildError(f"Qt6-specific hook triggered for non-Qt6 easyconfig?!")
 
 def parse_hook_maturin(ec, eprefix):
     """

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -676,7 +676,7 @@ def parse_hook_qt6_libinput(ec, eprefix):
                             f"No libinput dependency found for {ec.name} {ec.version}, please update relevant Qt6 hook"
                         )
     else:
-        raise EasyBuildError("maturin-specific hook triggered for non-maturin easyconfig?!")
+        raise EasyBuildError("Qt6-specific hook triggered for non-maturin easyconfig?!")
 
 def parse_hook_maturin(ec, eprefix):
     """

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -655,6 +655,29 @@ def parse_hook_qt5_check_qtwebengine_disable(ec, eprefix):
         raise EasyBuildError("Qt5-specific hook triggered for non-Qt5 easyconfig?!")
 
 
+def parse_hook_qt6_libinput(ec, eprefix):
+    """
+    Add dependency on libinput to Qt6.
+    This is not included in upstream EasyBuild as it brings a dependency on system-d
+    """
+    qt6_toolchain_version_to_libinput_version_map = {'14.3.0': '1.30.1'}
+    if ec.name == 'Qt6':
+        # Only enforcing from GCCcore 14.3.0 onwards for Qt6 6.9.3 onwards
+        if ec.toolchain.version >= '14.3.0':
+            if ec.version >= LooseVersion('6.9.3'):
+                dep_names = [dep[0] for dep in ec['dependencies']]
+                if 'libinput' not in dep_names:
+                    if ec.toolchain.version in qt6_toolchain_version_to_libinput_version_map.keys():
+                        libinput = ('libinput', qt6_toolchain_version_to_libinput_version_map[ec.toolchain.version])
+                        ec['dependencies'].append(libinput)
+                        print_msg(f"Added {libinput} dependency for {ec.name} {ec.version}")
+                    else:
+                        raise EasyBuildError(
+                            f"No libinput dependency found for {ec.name} {ec.version}, please update relevant Qt6 hook"
+                        )
+    else:
+        raise EasyBuildError("maturin-specific hook triggered for non-maturin easyconfig?!")
+
 def parse_hook_maturin(ec, eprefix):
     """
     Replace build dependency on Rust 1.88.0 by 1.91.1,
@@ -2003,6 +2026,7 @@ PARSE_HOOKS = {
     'OpenBLAS': parse_hook_openblas_relax_lapack_tests_num_errors,
     'pybind11': parse_hook_pybind11_replace_catch2,
     'Qt5': parse_hook_qt5_check_qtwebengine_disable,
+    'Qt6': parse_hook_qt6_libinput,
     'UCX': parse_hook_ucx_eprefix,
 }
 

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -663,7 +663,7 @@ def parse_hook_qt6_libinput(ec, eprefix):
     qt6_toolchain_version_to_libinput_version_map = {'14.3.0': '1.30.1'}
     if ec.name == 'Qt6':
         # Only enforcing from GCCcore 14.3.0 onwards for Qt6 6.9.3 onwards
-        if ec.toolchain.version >= '14.3.0':
+        if ec.toolchain.version >= LooseVersion('14.3.0'):
             if ec.version >= LooseVersion('6.9.3'):
                 dep_names = [dep[0] for dep in ec['dependencies']]
                 if 'libinput' not in dep_names:


### PR DESCRIPTION
Pretty easy to test:
```
{EESSI/2025.06} ocaisa@~/EESSI/software-layer-scripts(qt6_libinput)$ eb Qt6-6.9.3-GCCcore-14.2.0.eb -D --robot --hooks=./eb_hooks.py | grep libinput

{EESSI/2025.06} ocaisa@~/EESSI/software-layer-scripts(qt6_libinput)$ eb --from-pr 25901 -D --robot --hooks=./eb_hooks.py | grep libinput
== Added ('libinput', '1.30.1') dependency for Qt6 6.9.3
== Running parse hook for libinput-1.30.1-GCCcore-14.3.0.eb...
 * [x] /cvmfs/software.eessi.io/versions/2025.06/software/linux/aarch64/neoverse_n1/software/EasyBuild/5.3.0/easybuild/easyconfigs/l/libinput/libinput-1.30.1-GCCcore-14.3.0.eb (module:
libinput/1.30.1-GCCcore-14.3.0)

{EESSI/2025.06} ocaisa@~/EESSI/software-layer-scripts(qt6_libinput)$ eb --from-pr 25901  --hooks=./eb_hooks.py --module-only --force --robot
...

{EESSI/2025.06} ocaisa@~/EESSI/software-layer-scripts(qt6_libinput)$ grep libinput /home/ocaisa/eessi/versions/2025.06/software/linux/aarch64/neoverse_n1/modules/all/Qt6/6.9.3-GCCcore-14.3.0.lua
depends_on("libinput/1.30.1-GCCcore-14.3.0")
```