### PR TITLE
Allow different overrides for compat (i.e. CPU family) and modules (i.e. SOFTWARE_SUBDIR)

### DIFF
--- a/.github/workflows/tests_eessi_module.yml
+++ b/.github/workflows/tests_eessi_module.yml
@@ -338,17 +338,15 @@ jobs:
       - name: Test if we can override the CPU family to check risc-v modules on an x86 system
         run: |
           # Initialise Lmod
-          . /cvmfs/software.eessi.io/versions/${{matrix.EESSI_VERSION}}/init/lmod/bash
-
-          # Unload EESSI
-          module purge
+          . /cvmfs/software.eessi.io/versions/${{matrix.EESSI_VERSION}}/compat/linux/$(uname -m)/usr/share/Lmod/init/bash
+          
+          export MODULEPATH=init/modules
 
           # Set the overrides we want to test
           export EESSI_CPU_FAMILY_OVERRIDE=x86_64  # Running on an x86_64 system, so we need x86_64 compat layer
           export EESSI_SOFTWARE_SUBDIR_OVERRIDE=riscv64/generic  # Get modules for riscv64/generic
           export EESSI_VERSION_OVERRIDE=2025.06-001  # Override EESSI version, as versioning for riscv repo is different
-
-          # Load EESSI again with the overrides
+          
           module load EESSI/${{matrix.EESSI_VERSION}}
           
           # Make sure the compat layer works with a simple ls

--- a/.github/workflows/tests_eessi_module.yml
+++ b/.github/workflows/tests_eessi_module.yml
@@ -348,6 +348,12 @@ jobs:
           export EESSI_SOFTWARE_SUBDIR_OVERRIDE=riscv64/generic  # Get modules for riscv64/generic
           export EESSI_VERSION_OVERRIDE=2025.06-001  # Override EESSI version, as versioning for riscv repo is different
 
+          # Load EESSI again with the overrides
+          module load EESSI/${{matrix.EESSI_VERSION}}
+          
+          # Make sure the compat layer works with a simple ls
+          [ -n "${EPREFIX:-}" ] && "$EPREFIX/bin/ls" || { echo "EPREFIX is not defined" >&2; exit 1; }          
+          
           # Check that we have a riscv MODULEPATH
           if [[ "$MODULEPATH" == *"riscv"* ]]; then
               echo "MODULEPATH contains riscv prefix ($MODULEPATH)"

--- a/.github/workflows/tests_eessi_module.yml
+++ b/.github/workflows/tests_eessi_module.yml
@@ -316,6 +316,45 @@ jobs:
           GREP_PATTERN="Lmod is automatically replacing \"EESSI/${{matrix.EESSI_VERSION}}\" with \"${LOCAL_STACK_NAME}/${LOCAL_STACK_VERSION}\"."
           module load "${LOCAL_STACK_NAME}/${LOCAL_STACK_VERSION}" |& grep "${GREP_PATTERN}"
 
+  check_cpu_family_override:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        EESSI_VERSION:
+          - '2025.06'
+
+    steps:
+      - name: Check out software-layer repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Mount EESSI CernVM-FS repository
+        uses: cvmfs-contrib/github-action-cvmfs@55899ca74cf78ab874bdf47f5a804e47c198743c # v4.0
+        with:
+          cvmfs_config_package: https://github.com/EESSI/filesystem-layer/releases/download/latest/cvmfs-config-eessi_latest_all.deb
+          cvmfs_http_proxy: DIRECT
+          cvmfs_repositories: software.eessi.io,dev.eessi.io
+
+      - name: Test if we can override the CPU family to check aarch64 modules on an x86 system
+        run: |
+          # Initialise Lmod
+          . /cvmfs/software.eessi.io/versions/${{matrix.EESSI_VERSION}}/compat/linux/$(uname -m)/usr/share/Lmod/init/bash
+
+          # Unload EESSI
+          module purge
+
+          # Set the overrides we want to test
+          export EESSI_CPU_FAMILY_OVERRIDE=x86_64  # Running on an x86_64 system, so we need x86_64 compat layer
+          export EESSI_SOFTWARE_SUBDIR_OVERRIDE=riscv64/generic  # Get modules for riscv64/generic
+          export EESSI_VERSION_OVERRIDE=2025.06-001  # Override EESSI version, as versioning for riscv repo is different
+
+          # Check that we have a riscv MODULEPATH
+          if [[ "$MODULEPATH" == *"riscv"* ]]; then
+              echo "MODULEPATH contains riscv prefix ($MODULEPATH)"
+          else
+              exit 1
+          fi
+
   check_PS1_update_eessi_module:
     runs-on: ubuntu-24.04
     strategy:

--- a/.github/workflows/tests_eessi_module.yml
+++ b/.github/workflows/tests_eessi_module.yml
@@ -316,7 +316,7 @@ jobs:
           GREP_PATTERN="Lmod is automatically replacing \"EESSI/${{matrix.EESSI_VERSION}}\" with \"${LOCAL_STACK_NAME}/${LOCAL_STACK_VERSION}\"."
           module load "${LOCAL_STACK_NAME}/${LOCAL_STACK_VERSION}" |& grep "${GREP_PATTERN}"
 
-  check_cpu_family_override:
+  check_riscv_cpu_override:
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -335,10 +335,10 @@ jobs:
           cvmfs_http_proxy: DIRECT
           cvmfs_repositories: software.eessi.io,dev.eessi.io
 
-      - name: Test if we can override the CPU family to check aarch64 modules on an x86 system
+      - name: Test if we can override the CPU family to check risc-v modules on an x86 system
         run: |
           # Initialise Lmod
-          . /cvmfs/software.eessi.io/versions/${{matrix.EESSI_VERSION}}/compat/linux/$(uname -m)/usr/share/Lmod/init/bash
+          . /cvmfs/software.eessi.io/versions/${{matrix.EESSI_VERSION}}/init/lmod/bash
 
           # Unload EESSI
           module purge

--- a/init/modules/EESSI/2023.06.lua
+++ b/init/modules/EESSI/2023.06.lua
@@ -19,7 +19,11 @@ local eessi_init_prefix = pathJoin(eessi_prefix, "init")
 local eessi_software_layer_version_suffix = ""
 local eessi_os_type = "linux"
 -- for RISC-V clients we need to do some overrides, as things are stored in different CVMFS repositories
-if (subprocess("uname -m"):gsub("\n$","") == "riscv64") then
+local eessi_software_subdir_override = os.getenv("EESSI_SOFTWARE_SUBDIR_OVERRIDE")
+if (
+    subprocess("uname -m"):gsub("\n$","") == "riscv64"
+    or (eessi_software_subdir_override and string.find(eessi_software_subdir_override, "riscv64"))
+    ) then
     if (eessi_version == "2023.06" or eessi_version == "20240402") then
         eessi_version_override = os.getenv("EESSI_VERSION_OVERRIDE") or ""
         index_suffix = string.find(eessi_version_override, '-')
@@ -114,7 +118,12 @@ local archdetect = archdetect_cpu()
 -- archdetect_accel() attempts to identify an accelerator, e.g., accel/nvidia/cc80
 local archdetect_accel = archdetect_accel()
 -- eessi_cpu_family is derived from  the archdetect match, e.g., x86_64
-local eessi_cpu_family = archdetect:match("([^/]+)")
+local eessi_cpu_family
+if os.getenv("EESSI_CPU_FAMILY_OVERRIDE") then
+    eessi_cpu_family = os.getenv("EESSI_CPU_FAMILY_OVERRIDE")
+else
+    eessi_cpu_family = archdetect:match("([^/]+)")
+end
 local eessi_software_subdir = archdetect
 -- eessi_eprefix is the base location of the compat layer, e.g., /cvmfs/software.eessi.io/versions/<EESSI_VERSION>/compat/linux/x86_64
 local eessi_eprefix = pathJoin(eessi_compat_prefix, eessi_os_type, eessi_cpu_family)


### PR DESCRIPTION
This faciliates e.g. checking of the available RISCV modules on an X86_64 host.

This is useful for e.g. running the test suite on an x86_64-based login node, when targetting RISCV-based batch nodes. The reason is that the test suite generates tests based on the available modules, so on the login node (where the reframe runtime runs), we want to see the RISCV modules. 

This change allows doing
```
EESSI_CPU_FAMILY_OVERRIDE=x86_64 EESSI_VERSION_OVERRIDE=2025.06-001 EESSI_SOFTWARE_SUBDIR_OVERRIDE=riscv64/generic module load EESSI/2025.06
```
on an X86_64-based host, and make the RISC-V module stack available:

```
$ module av

--------------------------------------------------------- /cvmfs/dev.eessi.io/riscv/versions/2025.06-001/software/linux/riscv64/generic/modules/all ---------------------------------------------------------
   Abseil/20250512.1-GCCcore-14.3.0              FFTW.MPI/3.3.10-gompi-2025a                         libidn2/2.3.8-GCCcore-14.3.0           (D)    Perl/5.38.0
...
```

Admittedly, the usage is a bit restricted since this is really only useful if module stacks are NOT in sync _and_ if the CPU family for the target of interest is different from the one on the host. Then again, it is an override: nothing changes in the default behavior, and you don't set it unless you have very good reasons to. It simply allows us extra flexibility when testing things.

Issue came up in https://github.com/EESSI/dev.eessi.io-riscv/issues/34#issuecomment-4387220708 when trying to set up period tests on the RISC-V cluster.