### PR TITLE
Ignore ROCm-LLVM on aarch64

### DIFF
--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -846,10 +846,11 @@ def is_unsupported_module(self):
     if not os.getenv("EESSI_OVERRIDE_ROCM_VERSION_CHECK"):
         if self.cfg.name == 'ROCm-LLVM' and self.cfg.version in ('6.4.1',):
             if get_eessi_envvar('EESSI_CPU_FAMILY') == 'aarch64':
-                msg = "ROCm-LLVM/6.4.1 is not supported on aarch64 architectures. "
                 msg += "Building with '--module-only --force' and injecting an LmodError into the modulefile."
                 msg += "You can override this behaviour by setting the EESSI_OVERRIDE_ROCM_VERSION_CHECK environment variable."
                 print_warning(msg)
+                errmsg = "ROCm-LLVM/6.4.1 is not supported on the aarch64 architecture."
+                errmsg += "For more details, see: https://github.com/EESSI/software-layer/pull/1473#issuecomment-4370846033"
                 var=EESSI_IGNORE_AARCH64_ROCMLLVM641_ENVVAR
                 setattr(self, EESSI_UNSUPPORTED_MODULE_ATTR, UnsupportedModule(envvar=var, errmsg=errmsg))
                 return True

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -844,7 +844,7 @@ def is_unsupported_module(self):
     # ROCm-LLVM 6.4.1 is not supported on aarch64
     # see: https://github.com/EESSI/software-layer/pull/1473#issuecomment-4370846033
     if not os.getenv("EESSI_OVERRIDE_ROCM_VERSION_CHECK"):
-        if ec.name == 'ROCm-LLVM' and ec.version in ('6.4.1',):
+        if self.cfg.name == 'ROCm-LLVM' and self.cfg.version in ('6.4.1',):
             if get_eessi_envvar('EESSI_CPU_FAMILY') == 'aarch64':
                 msg = "ROCm-LLVM/6.4.1 is not supported on aarch64 architectures. "
                 msg += "Building with '--module-only --force' and injecting an LmodError into the modulefile."

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -55,6 +55,7 @@ HOST_INJECTIONS_LOCATION = "/cvmfs/software.eessi.io/host_injections/"
 
 # Make sure a single environment variable name is used for this throughout the hooks
 EESSI_IGNORE_ZEN4_GCC1220_ENVVAR="EESSI_IGNORE_LMOD_ERROR_ZEN4_GCC1220"
+EESSI_IGNORE_AARCH64_ROCMLLVM641_ENVVAR="EESSI_IGNORE_LMOD_ERROR_AARCH64_ROCMLLVM641"
 
 STACK_REPROD_SUBDIR = 'reprod'
 
@@ -839,6 +840,19 @@ def is_unsupported_module(self):
                     errmsg +=f"Capabilities: {cuda_ccs}.\\n"
                     setattr(self, EESSI_UNSUPPORTED_MODULE_ATTR, UnsupportedModule(envvar=var,errmsg=errmsg))
                     return True
+
+    # ROCm-LLVM 6.4.1 is not supported on aarch64
+    # see: https://github.com/EESSI/software-layer/pull/1473#issuecomment-4370846033
+    if not os.getenv("EESSI_OVERRIDE_ROCM_VERSION_CHECK"):
+        if ec.name == 'ROCm-LLVM' and ec.version in ('6.4.1',):
+            if get_eessi_envvar('EESSI_CPU_FAMILY') == 'aarch64':
+                msg = "ROCm-LLVM/6.4.1 is not supported on aarch64 architectures. "
+                msg += "Building with '--module-only --force' and injecting an LmodError into the modulefile."
+                msg += "You can override this behaviour by setting the EESSI_OVERRIDE_ROCM_VERSION_CHECK environment variable."
+                print_warning(msg)
+                var=EESSI_IGNORE_AARCH64_ROCMLLVM641_ENVVAR
+                setattr(self, EESSI_UNSUPPORTED_MODULE_ATTR, UnsupportedModule(envvar=var, errmsg=errmsg))
+                return True
 
     # If all the above logic passed, this module is supported
     setattr(self, EESSI_SUPPORTED_MODULE_ATTR, True)

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -55,7 +55,6 @@ HOST_INJECTIONS_LOCATION = "/cvmfs/software.eessi.io/host_injections/"
 
 # Make sure a single environment variable name is used for this throughout the hooks
 EESSI_IGNORE_ZEN4_GCC1220_ENVVAR="EESSI_IGNORE_LMOD_ERROR_ZEN4_GCC1220"
-EESSI_IGNORE_AARCH64_ROCMLLVM641_ENVVAR="EESSI_IGNORE_LMOD_ERROR_AARCH64_ROCMLLVM641"
 
 STACK_REPROD_SUBDIR = 'reprod'
 
@@ -840,20 +839,6 @@ def is_unsupported_module(self):
                     errmsg +=f"Capabilities: {cuda_ccs}.\\n"
                     setattr(self, EESSI_UNSUPPORTED_MODULE_ATTR, UnsupportedModule(envvar=var,errmsg=errmsg))
                     return True
-
-    # ROCm-LLVM 6.4.1 is not supported on aarch64
-    # see: https://github.com/EESSI/software-layer/pull/1473#issuecomment-4370846033
-    if not os.getenv("EESSI_OVERRIDE_ROCM_VERSION_CHECK"):
-        if self.cfg.name == 'ROCm-LLVM' and self.cfg.version in ('6.4.1',):
-            if get_eessi_envvar('EESSI_CPU_FAMILY') == 'aarch64':
-                msg += "Building with '--module-only --force' and injecting an LmodError into the modulefile."
-                msg += "You can override this behaviour by setting the EESSI_OVERRIDE_ROCM_VERSION_CHECK environment variable."
-                print_warning(msg)
-                errmsg = "ROCm-LLVM/6.4.1 is not supported on the aarch64 architecture."
-                errmsg += "For more details, see: https://github.com/EESSI/software-layer/pull/1473#issuecomment-4370846033"
-                var=EESSI_IGNORE_AARCH64_ROCMLLVM641_ENVVAR
-                setattr(self, EESSI_UNSUPPORTED_MODULE_ATTR, UnsupportedModule(envvar=var, errmsg=errmsg))
-                return True
 
     # If all the above logic passed, this module is supported
     setattr(self, EESSI_SUPPORTED_MODULE_ATTR, True)

--- a/init/modules/EESSI/2023.06.lua
+++ b/init/modules/EESSI/2023.06.lua
@@ -181,7 +181,7 @@ if not (archdetect_accel == nil or archdetect_accel == '') then
     eessi_module_path_accel = pathJoin(eessi_accel_software_path, archdetect_accel, eessi_modules_subdir)
     eessiDebug("Checking if " .. eessi_module_path_accel .. " exists")
     if eessi_cpu_family == "aarch64" and archdetect_accel:match("^accel/amd/") then
-        LmodMessage("aarch64 CPU detected, no support for AMD GPUs in production repository yet.")
+        LmodMessage("aarch64 CPU detected, AMD ROCm doesn't support aarch64 yet")
     end
     if not isDir(eessi_module_path_accel) then
         -- fall back to major version GPU arch if the exact one is not an option (i.e, 7.5 -> 7.0)

--- a/init/modules/EESSI/2023.06.lua
+++ b/init/modules/EESSI/2023.06.lua
@@ -180,6 +180,9 @@ if not (archdetect_accel == nil or archdetect_accel == '') then
     -- /cvmfs/software.eessi.io/versions/<EESSI_VERSION>/software/linux/x86_64/amd/zen3/accel/nvidia/cc80/modules/all
     eessi_module_path_accel = pathJoin(eessi_accel_software_path, archdetect_accel, eessi_modules_subdir)
     eessiDebug("Checking if " .. eessi_module_path_accel .. " exists")
+    if eessi_cpu_family == "aarch64" and archdetect_accel:match("^accel/amd/") then
+        LmodMessage("aarch64 CPU detected, no support for AMD GPUs in production repository yet.")
+    end
     if not isDir(eessi_module_path_accel) then
         -- fall back to major version GPU arch if the exact one is not an option (i.e, 7.5 -> 7.0)
         local original_archdetect_accel = archdetect_accel

--- a/init/modules/EESSI/2023.06.lua
+++ b/init/modules/EESSI/2023.06.lua
@@ -181,7 +181,7 @@ if not (archdetect_accel == nil or archdetect_accel == '') then
     eessi_module_path_accel = pathJoin(eessi_accel_software_path, archdetect_accel, eessi_modules_subdir)
     eessiDebug("Checking if " .. eessi_module_path_accel .. " exists")
     if eessi_cpu_family == "aarch64" and archdetect_accel:match("^accel/amd/") then
-        LmodMessage("aarch64 CPU detected, AMD ROCm doesn't support aarch64 yet")
+        LmodMessage("AArch64 CPU architecture and AMD GPU detected. However, AMD ROCm does not support AArch64. Thus, AMD GPU-enabled EESSI installations are not available on this system.")
     end
     if not isDir(eessi_module_path_accel) then
         -- fall back to major version GPU arch if the exact one is not an option (i.e, 7.5 -> 7.0)


### PR DESCRIPTION
ROCm-LLVM 6.4.1 is not supported on aarch64 family of CPUs.

See: https://github.com/EESSI/software-layer/pull/1473#issuecomment-4370846033