### PR TITLE
Allow for CUDA driver minor version compatibility

### DIFF
--- a/create_lmodsitepackage.py
+++ b/create_lmodsitepackage.py
@@ -229,12 +229,6 @@ local function eessi_cuda_and_libraries_enabled_load_hook(t)
                                         pushenv(suppress_var, myModuleName())
                                     end
                                 end
-                                if (mode() == "unload") then
-                                    if suppress_warn == myModuleName() then
-                                        -- make sure the variable eventually gets unset
-                                        pushenv(suppress_var, myModuleName())
-                                    end
-                                end
                             end
                         end
                         if driver_libs_need_update == true then

--- a/create_lmodsitepackage.py
+++ b/create_lmodsitepackage.py
@@ -208,7 +208,7 @@ local function eessi_cuda_and_libraries_enabled_load_hook(t)
                         warn = warn .. "Cannot ensure that driver version is new enough for CUDA toolkit version: '"
                         warn = warn .. cudaVersion_req .. "'. This module will still be loaded, but may not function "
                         warn = warn .. "as expected. Export " .. suppress_var .. "=1"
-                        if not suppress_warn or suppress_warn == 1 then
+                        if not suppress_warn or suppress_warn == "1" then
                             LmodWarning(warn)
                         end
                     else
@@ -223,9 +223,17 @@ local function eessi_cuda_and_libraries_enabled_load_hook(t)
                                 local warn = "but the module you want to load requires CUDA " .. cudaVersion_req .. ". "
                                 warn = warn .. "You will therefore be in minor version compatibility mode as described in "
                                 warn = warn .. "https://docs.nvidia.com/deploy/cuda-compatibility/minor-version-compatibility.html .\\n"
-                                if not suppress_warn or suppress_warn == 1 then
+                                if not suppress_warn or suppress_warn == "1" then
                                     LmodWarning("\\nYour driver CUDA version is ", cudaVersion, " ", warn)
-                                    setenv(suppress_var, "1")
+                                    if not suppress_warn then
+                                        pushenv(suppress_var, myModuleName())
+                                    end
+                                end
+                                if (mode() == "unload") then
+                                    if suppress_warn == myModuleName() then
+                                        -- make sure the variable eventually gets unset
+                                        pushenv(suppress_var, myModuleName())
+                                    end
                                 end
                             end
                         end

--- a/create_lmodsitepackage.py
+++ b/create_lmodsitepackage.py
@@ -201,13 +201,13 @@ local function eessi_cuda_and_libraries_enabled_load_hook(t)
                     -- Account for the fact that the script sourced above was designed to never return a non-zero exit code,
                     -- even if it fails to set EESSI_CUDA_DRIVER_VERSION
                     -- Essentially, we handle that case here by raising an error, which can be suppressed
+                    local suppress_var = "EESSI_CUDA_DRIVER_VERSION_SUPPRESS_WARNING"
+                    local suppress_warn = os.getenv(suppress_var)
                     if not cudaVersion or cudaVersion == "" then
-                        local suppress_var = "EESSI_CUDA_DRIVER_VERSION_SUPPRESS_WARNING"
                         local warn = "Environment variable EESSI_CUDA_DRIVER_VERSION not found. "
                         warn = warn .. "Cannot ensure that driver version is new enough for CUDA toolkit version: '"
                         warn = warn .. cudaVersion_req .. "'. This module will still be loaded, but may not function "
                         warn = warn .. "as expected. Export " .. suppress_var .. "=1"
-                        local suppress_warn = os.getenv(suppress_var)
                         if not suppress_warn or suppress_warn == 1 then
                             LmodWarning(warn)
                         end
@@ -220,14 +220,16 @@ local function eessi_cuda_and_libraries_enabled_load_hook(t)
                             driver_libs_need_update = true
                         elseif tonumber(major) == tonumber(major_req) then
                             if tonumber(minor) < tonumber(minor_req) then
-                                local advice = "but the module you want to load requires CUDA  " .. cudaVersion_req .. ". "
-                                advice = advice .. "You will therefore be in minor version compatibility mode as described in "
-                                advice = advice .. "https://docs.nvidia.com/deploy/cuda-compatibility/minor-version-compatibility.html .\\n"
-                                LmodWarning("\\nYour driver CUDA version is ", cudaVersion, " ", advice)
+                                local warn = "but the module you want to load requires CUDA " .. cudaVersion_req .. ". "
+                                warn = warn .. "You will therefore be in minor version compatibility mode as described in "
+                                warn = warn .. "https://docs.nvidia.com/deploy/cuda-compatibility/minor-version-compatibility.html .\\n"
+                                if not suppress_warn or suppress_warn == 1 then
+                                    LmodWarning("\\nYour driver CUDA version is ", cudaVersion, " ", warn)
+                                end
                             end
                         end
                         if driver_libs_need_update == true then
-                            local advice = "but the module you want to load requires CUDA  " .. cudaVersion_req .. ". "
+                            local advice = "but the module you want to load requires CUDA " .. cudaVersion_req .. ". "
                             advice = advice .. "Please update your CUDA driver libraries and then "
                             advice = advice .. "let EESSI know about the update.\\n"
                             advice = advice .. refer_to_docs

--- a/create_lmodsitepackage.py
+++ b/create_lmodsitepackage.py
@@ -161,9 +161,9 @@ local function eessi_cuda_and_libraries_enabled_load_hook(t)
     local checkGpu = mt:haveProperty(simpleName,"arch","gpu")
     local overrideGpuCheck = os.getenv("EESSI_OVERRIDE_GPU_CHECK")
     if checkGpu and (overrideGpuCheck == nil) then
-        local eessi_version = os.getenv('EESSI_VERSION')
-        local eessi_eprefix = os.getenv("EESSI_EPREFIX")
-        if eessi_eprefix == nil or eessi_version == nil then
+        local eessi_version = os.getenv('EESSI_VERSION') or ""
+        local eessi_eprefix = os.getenv("EESSI_EPREFIX") or ""
+        if eessi_eprefix == "" or eessi_version == "" then
             LmodError("EESSI_VERSION and EESSI_EPREFIX must be defined for GPU driver check to work\\n")
         end
         -- Having EESSICUDAVERSION set means we have an NVIDIA accelerator

--- a/create_lmodsitepackage.py
+++ b/create_lmodsitepackage.py
@@ -225,6 +225,7 @@ local function eessi_cuda_and_libraries_enabled_load_hook(t)
                                 warn = warn .. "https://docs.nvidia.com/deploy/cuda-compatibility/minor-version-compatibility.html .\\n"
                                 if not suppress_warn or suppress_warn == 1 then
                                     LmodWarning("\\nYour driver CUDA version is ", cudaVersion, " ", warn)
+                                    setenv(suppress_var, "1")
                                 end
                             end
                         end

--- a/create_lmodsitepackage.py
+++ b/create_lmodsitepackage.py
@@ -161,72 +161,78 @@ local function eessi_cuda_and_libraries_enabled_load_hook(t)
     local checkGpu = mt:haveProperty(simpleName,"arch","gpu")
     local overrideGpuCheck = os.getenv("EESSI_OVERRIDE_GPU_CHECK")
     if checkGpu and (overrideGpuCheck == nil) then
-        local eessi_version = os.getenv('EESSI_VERSION') or ""
-        local eessi_eprefix = os.getenv("EESSI_EPREFIX") or ""
+        local eessi_version = os.getenv('EESSI_VERSION')
+        local eessi_eprefix = os.getenv("EESSI_EPREFIX")
         if eessi_eprefix == nil or eessi_version == nil then
             LmodError("EESSI_VERSION and EESSI_EPREFIX must be defined for GPU driver check to work\\n")
         end
-        local cudaDriverDir = nil
-        if eessi_version == "2023.06" then
-            cudaDriverDir = string.gsub(eessi_eprefix, 'versions', 'host_injections') .. "/lib"
-        else
-            cudaDriverDir = eessi_eprefix .. "/lib/nvidia"
-        end
-        local cudaDriverFile = cudaDriverDir .. "/libcuda.so"
-        local cudaDriverExists = isFile(cudaDriverFile)
-        local singularityCudaExists = isFile("/.singularity.d/libs/libcuda.so")
-        if not (cudaDriverExists or singularityCudaExists)  then
-            local advice = "which relies on the CUDA runtime environment and driver libraries. "
-            advice = advice .. "In order to be able to use the module, you will need "
-            advice = advice .. "to make sure EESSI can find the GPU driver libraries on your host system. "
-            advice = advice .. "The file being checked for on your system is \\n" .. cudaDriverFile .. "\\n"
-            advice = advice .. "You can override this check by setting the environment variable "
-            advice = advice .. "EESSI_OVERRIDE_GPU_CHECK but "
-            advice = advice .. "the loaded application will not be able to execute on your system.\\n"
-            advice = advice .. refer_to_docs
-            LmodError("\\nYou requested to load ", simpleName, " ", advice)
-        else
-            -- CUDA driver exists, now we check its version to see if an update is needed
-            if cudaDriverExists then
-                local cudaVersion = os.getenv("EESSI_CUDA_DRIVER_VERSION")
-                if not cudaVersion or cudaVersion == "" then
-                    local eessi_prefix = os.getenv("EESSI_PREFIX")
-                    local script = pathJoin(eessi_prefix, 'scripts', 'gpu_support', 'nvidia', 'get_cuda_driver_version.sh')
-                    source_sh("bash", script)
-                end
-                cudaVersion = os.getenv("EESSI_CUDA_DRIVER_VERSION")
-                local cudaVersion_req = os.getenv("EESSICUDAVERSION")
-                -- Account for the fact that the script sourced above was designed to never return a non-zero exit code,
-                -- even if it fails to set EESSI_CUDA_DRIVER_VERSION
-                -- Essentially, we handle that case here by raising an error, which can be suppressed
-                if not cudaVersion or cudaVersion == "" then
-                    local suppress_var = "EESSI_CUDA_DRIVER_VERSION_SUPPRESS_WARNING"
-                    local warn = "Environment variable EESSI_CUDA_DRIVER_VERSION not found. "
-                    warn = warn .. "Cannot ensure that driver version is new enough for CUDA toolkit version: '"
-                    warn = warn .. cudaVersion_req .. "'. This module will still be loaded, but may not function "
-                    warn = warn .. "as expected. Export " .. suppress_var .. "=1"
-                    local suppress_warn = os.getenv(suppress_var)
-                    if not suppress_warn or suppress_warn == 1 then
-                        LmodWarning(warn)
+        -- Having EESSICUDAVERSION set means we have an NVIDIA accelerator
+        local cudaVersion_req = os.getenv("EESSICUDAVERSION")
+        if cudaVersion_req then
+            local cudaDriverDir = nil
+            if eessi_version == "2023.06" then
+                cudaDriverDir = string.gsub(eessi_eprefix, 'versions', 'host_injections') .. "/lib"
+            else
+                cudaDriverDir = eessi_eprefix .. "/lib/nvidia"
+            end
+            local cudaDriverFile = cudaDriverDir .. "/libcuda.so"
+            local cudaDriverExists = isFile(cudaDriverFile)
+            local singularityCudaExists = isFile("/.singularity.d/libs/libcuda.so")
+            if not (cudaDriverExists or singularityCudaExists)  then
+                local advice = "which relies on the CUDA runtime environment and driver libraries. "
+                advice = advice .. "In order to be able to use the module, you will need "
+                advice = advice .. "to make sure EESSI can find the GPU driver libraries on your host system. "
+                advice = advice .. "The file being checked for on your system is \\n" .. cudaDriverFile .. "\\n"
+                advice = advice .. "You can override this check by setting the environment variable "
+                advice = advice .. "EESSI_OVERRIDE_GPU_CHECK but "
+                advice = advice .. "the loaded application will not be able to execute on your system.\\n"
+                advice = advice .. refer_to_docs
+                LmodError("\\nYou requested to load ", simpleName, " ", advice)
+            else
+                -- CUDA driver exists, now we check its version to see if an update is needed
+                if cudaDriverExists then
+                    local cudaVersion = os.getenv("EESSI_CUDA_DRIVER_VERSION")
+                    if not cudaVersion or cudaVersion == "" then
+                        local eessi_prefix = os.getenv("EESSI_PREFIX")
+                        local script = pathJoin(eessi_prefix, 'scripts', 'gpu_support', 'nvidia', 'get_cuda_driver_version.sh')
+                        source_sh("bash", script)
                     end
-                else
-                    -- driver CUDA versions don't give a patch version for CUDA
-                    local major, minor = string.match(cudaVersion, "(%d+)%.(%d+)")
-                    local major_req, minor_req, patch_req = string.match(cudaVersion_req, "(%d+)%.(%d+)%.(%d+)")
-                    local driver_libs_need_update = false
-                    if tonumber(major) < tonumber(major_req) then
-                        driver_libs_need_update = true
-                    elseif tonumber(major) == tonumber(major_req) then
-                        if tonumber(minor) < tonumber(minor_req) then
-                            driver_libs_need_update = true
+                    cudaVersion = os.getenv("EESSI_CUDA_DRIVER_VERSION")
+                    -- Account for the fact that the script sourced above was designed to never return a non-zero exit code,
+                    -- even if it fails to set EESSI_CUDA_DRIVER_VERSION
+                    -- Essentially, we handle that case here by raising an error, which can be suppressed
+                    if not cudaVersion or cudaVersion == "" then
+                        local suppress_var = "EESSI_CUDA_DRIVER_VERSION_SUPPRESS_WARNING"
+                        local warn = "Environment variable EESSI_CUDA_DRIVER_VERSION not found. "
+                        warn = warn .. "Cannot ensure that driver version is new enough for CUDA toolkit version: '"
+                        warn = warn .. cudaVersion_req .. "'. This module will still be loaded, but may not function "
+                        warn = warn .. "as expected. Export " .. suppress_var .. "=1"
+                        local suppress_warn = os.getenv(suppress_var)
+                        if not suppress_warn or suppress_warn == 1 then
+                            LmodWarning(warn)
                         end
-                    end
-                    if driver_libs_need_update == true then
-                        local advice = "but the module you want to load requires CUDA  " .. cudaVersion_req .. ". "
-                        advice = advice .. "Please update your CUDA driver libraries and then "
-                        advice = advice .. "let EESSI know about the update.\\n"
-                        advice = advice .. refer_to_docs
-                        LmodError("\\nYour driver CUDA version is ", cudaVersion, " ", advice)
+                    else
+                        -- driver CUDA versions don't give a patch version for CUDA
+                        local major, minor = string.match(cudaVersion, "(%d+)%.(%d+)")
+                        local major_req, minor_req, patch_req = string.match(cudaVersion_req, "(%d+)%.(%d+)%.(%d+)")
+                        local driver_libs_need_update = false
+                        if tonumber(major) < tonumber(major_req) then
+                            driver_libs_need_update = true
+                        elseif tonumber(major) == tonumber(major_req) then
+                            if tonumber(minor) < tonumber(minor_req) then
+                                local advice = "but the module you want to load requires CUDA  " .. cudaVersion_req .. ". "
+                                advice = advice .. "You will therefore be in minor version compatibility mode as described in "
+                                advice = advice .. "https://docs.nvidia.com/deploy/cuda-compatibility/minor-version-compatibility.html .\\n"
+                                LmodWarning("\\nYour driver CUDA version is ", cudaVersion, " ", advice)
+                            end
+                        end
+                        if driver_libs_need_update == true then
+                            local advice = "but the module you want to load requires CUDA  " .. cudaVersion_req .. ". "
+                            advice = advice .. "Please update your CUDA driver libraries and then "
+                            advice = advice .. "let EESSI know about the update.\\n"
+                            advice = advice .. refer_to_docs
+                            LmodError("\\nYour driver CUDA version is ", cudaVersion, " ", advice)
+                        end
                     end
                 end
             end


### PR DESCRIPTION
It works, but is a little too chatty:
```
{EESSI/2023.06} [aocais00@lrdn3368 software-layer-scripts]$ module load OSU-Micro-Benchmarks/7.5-gompi-2023b-CUDA-12.4.0
Lmod Warning:
Your driver CUDA version is 12.2  but the module you want to load requires CUDA 12.4.0. You will therefore be in minor version compatibility mode as described in
https://docs.nvidia.com/deploy/cuda-compatibility/minor-version-compatibility.html .

While processing the following module(s):
    Module fullname                                   Module Filename
    ---------------                                   ---------------
    UCX-CUDA/1.15.0-GCCcore-13.2.0-CUDA-12.4.0        /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/icelake/accel/nvidia/cc80/modules/all/UCX-CUDA/1.15.0-GCCcore-13.2.0-CUDA-12.4.0.lua
    NCCL/2.20.5-GCCcore-13.2.0-CUDA-12.4.0            /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/icelake/accel/nvidia/cc80/modules/all/NCCL/2.20.5-GCCcore-13.2.0-CUDA-12.4.0.lua
    OSU-Micro-Benchmarks/7.5-gompi-2023b-CUDA-12.4.0  /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/icelake/accel/nvidia/cc80/modules/all/OSU-Micro-Benchmarks/7.5-gompi-2023b-CUDA-12.4.0.lua

Lmod Warning:
Your driver CUDA version is 12.2  but the module you want to load requires CUDA 12.4.0. You will therefore be in minor version compatibility mode as described in
https://docs.nvidia.com/deploy/cuda-compatibility/minor-version-compatibility.html .

While processing the following module(s):
    Module fullname                                   Module Filename
    ---------------                                   ---------------
    NCCL/2.20.5-GCCcore-13.2.0-CUDA-12.4.0            /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/icelake/accel/nvidia/cc80/modules/all/NCCL/2.20.5-GCCcore-13.2.0-CUDA-12.4.0.lua
    OSU-Micro-Benchmarks/7.5-gompi-2023b-CUDA-12.4.0  /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/icelake/accel/nvidia/cc80/modules/all/OSU-Micro-Benchmarks/7.5-gompi-2023b-CUDA-12.4.0.lua

Lmod Warning:
Your driver CUDA version is 12.2  but the module you want to load requires CUDA 12.4.0. You will therefore be in minor version compatibility mode as described in
https://docs.nvidia.com/deploy/cuda-compatibility/minor-version-compatibility.html .

While processing the following module(s):
    Module fullname                                   Module Filename
    ---------------                                   ---------------
    UCC-CUDA/1.2.0-GCCcore-13.2.0-CUDA-12.4.0         /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/icelake/accel/nvidia/cc80/modules/all/UCC-CUDA/1.2.0-GCCcore-13.2.0-CUDA-12.4.0.lua
    OSU-Micro-Benchmarks/7.5-gompi-2023b-CUDA-12.4.0  /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/icelake/accel/nvidia/cc80/modules/all/OSU-Micro-Benchmarks/7.5-gompi-2023b-CUDA-12.4.0.lua

Lmod Warning:
Your driver CUDA version is 12.2  but the module you want to load requires CUDA 12.4.0. You will therefore be in minor version compatibility mode as described in
https://docs.nvidia.com/deploy/cuda-compatibility/minor-version-compatibility.html .

While processing the following module(s):
    Module fullname                                   Module Filename
    ---------------                                   ---------------
    OSU-Micro-Benchmarks/7.5-gompi-2023b-CUDA-12.4.0  /cvmfs/software.eessi.io/versions/2023.06/software/linux/x86_64/intel/icelake/accel/nvidia/cc80/modules/all/OSU-Micro-Benchmarks/7.5-gompi-2023b-CUDA-12.4.0.lua
```