### PR TITLE
Fix EESSI-extend CI by doing a `module --force purge`

### DIFF
--- a/.github/workflows/tests_eessi_extend_module.yml
+++ b/.github/workflows/tests_eessi_extend_module.yml
@@ -34,7 +34,7 @@ jobs:
 
           # Let's start from a clean slate (unload the EESSI module)
           module --force purge
-          check_disallowed_env_prefix EESSI_
+          check_disallowed_env_prefix EESSI_ EESSI_MODULE_STICKY
           check_disallowed_env_prefix EASYBUILD_
 
           # Load the EESSI module

--- a/.github/workflows/tests_eessi_extend_module.yml
+++ b/.github/workflows/tests_eessi_extend_module.yml
@@ -33,7 +33,7 @@ jobs:
           source .github/workflows/scripts/test_utils.sh
 
           # Let's start from a clean slate (unload the EESSI module)
-          module purge
+          module --force purge
           check_disallowed_env_prefix EESSI_
           check_disallowed_env_prefix EASYBUILD_
 
@@ -67,7 +67,7 @@ jobs:
           source .github/workflows/scripts/test_utils.sh
 
           # Let's start from a clean slate
-          module purge
+          module --force purge
           module load EESSI/${{matrix.EESSI_VERSION}}
           # Access the installed EESSI-extend
           module use "$MY_INSTALLATION_PATH"/modules/all
@@ -161,7 +161,7 @@ jobs:
           export STORED_CUDA_CC="8.0"
 
           # Let's start from a clean slate
-          module purge
+          module --force purge
           export EESSI_ACCELERATOR_TARGET_OVERRIDE=$STORED_EESSI_ACCELERATOR_TARGET_OVERRIDE
           module load EESSI/${{matrix.EESSI_VERSION}}
           # Access the installed EESSI-extend


### PR DESCRIPTION
Seems required because https://github.com/EESSI/github-action-eessi/pull/36 made the EESSI module sticky.