### PR TITLE
Update site package behavior

### DIFF
--- a/.github/workflows/scripts/verify_eessi_environment.py
+++ b/.github/workflows/scripts/verify_eessi_environment.py
@@ -32,6 +32,11 @@ def check_env_endswith(var1, var2):
     if not val1.endswith(val2):
         raise EnvVarError(f"'{var1}' must end with '{var2}':\n{var1}='{val1}'\n{var2}='{val2}'")
 
+def check_env_startswith(var1, var2):
+    val1, val2 = get_env_vars(var1, var2)
+    if not val1.startswith(val2):
+        raise EnvVarError(f"'{var1}' must start with '{var2}':\n{var1}='{val1}'\n{var2}='{val2}'")
+
 if __name__ == "__main__":
     try:
         # accelerator stuff is not guaranteed to exist
@@ -58,6 +63,10 @@ if __name__ == "__main__":
             check_env_contains("EESSI_SITE_MODULEPATH_ACCEL", "EESSI_SOFTWARE_SUBDIR")
             check_env_contains("EESSI_MODULEPATH_ACCEL", "EESSI_ACCELERATOR_TARGET")
             check_env_contains("EESSI_SITE_MODULEPATH_ACCEL", "EESSI_ACCELERATOR_TARGET")
+        # Verify that configuring an EESSI_SITE_SOFTWARE_PREFIX results in this prefix being
+        # the first part of EESSI_SITE_SOFTWARE_PATH
+        if os.getenv("EESSI_SITE_SOFTWARE_PREFIX"):
+            check_env_startswith("EESSI_SITE_SOFTWARE_PATH", "EESSI_SITE_SOFTWARE_PREFIX")
         # Finally, verify that all the expected module path are included
         check_env_contains("MODULEPATH", "EESSI_MODULEPATH")
         check_env_contains("MODULEPATH", "EESSI_SITE_MODULEPATH")

--- a/.github/workflows/scripts/verify_eessi_environment.py
+++ b/.github/workflows/scripts/verify_eessi_environment.py
@@ -67,6 +67,9 @@ if __name__ == "__main__":
         # the first part of EESSI_SITE_SOFTWARE_PATH
         if os.getenv("EESSI_SITE_SOFTWARE_PREFIX"):
             check_env_startswith("EESSI_SITE_SOFTWARE_PATH", "EESSI_SITE_SOFTWARE_PREFIX")
+            check_env_startswith("EESSI_SITE_MODULEPATH", "EESSI_SITE_SOFTWARE_PREFIX")
+            if expected_eessi_accel_arch:
+                check_env_startswith("EESSI_SITE_MODULEPATH_ACCEL", "EESSI_SITE_SOFTWARE_PREFIX")
         # Finally, verify that all the expected module path are included
         check_env_contains("MODULEPATH", "EESSI_MODULEPATH")
         check_env_contains("MODULEPATH", "EESSI_SITE_MODULEPATH")

--- a/.github/workflows/tests_eessi_module.yml
+++ b/.github/workflows/tests_eessi_module.yml
@@ -171,6 +171,9 @@ jobs:
           FINAL_ACCELERATOR_TARGET_EXPECTED: accel/nvidia/cc80
         - EESSI_ACCELERATOR_TARGET_OVERRIDE: accel/nvidia/cc77  # deliberately chose a non-existent CUDA capability
           FINAL_ACCELERATOR_TARGET_EXPECTED: accel/nvidia/cc70  # this reverts to the fallback case (which does exist)
+          # Test if setting an EESSI_SITE_SOFTWARE_PREFIX works by setting that for the zen4 target
+        - EESSI_SOFTWARE_SUBDIR_OVERRIDE: x86_64/amd/zen4
+          EESSI_SITE_SOFTWARE_PREFIX: /tmp/site_prefix
 
     steps:
       - name: Check out software-layer repository

--- a/.github/workflows/tests_eessi_module.yml
+++ b/.github/workflows/tests_eessi_module.yml
@@ -221,7 +221,11 @@ jobs:
           # We create this dir the the verify_eessi_environment.py later on, since the EESSI_SITE_MODULEPATH_ACCEL
           # will only be set if this dir exists - and we can most easily create it here, where we have
           # EESSI_SITE_SOFTWARE_PATH and EESSI_ACCEL_SOFTWARE_SUBDIR available
-          mkdir -p $EESSI_SITE_SOFTWARE_PATH/$EESSI_ACCEL_SUBDIR
+          # DEBUG OUTPUT:
+          ls -al /cvmfs/software.eessi.io/host_injections
+          mkdir -p /opt/eessi
+          ls -al /cvmfs/software.eessi.io/host_injections
+          mkdir -p "$EESSI_SITE_SOFTWARE_PATH/$EESSI_ACCEL_SUBDIR"
           module unload EESSI/${{matrix.EESSI_VERSION}}
           env | grep -v _ModuleTable | sort > "${module_cycled_file}"
 

--- a/.github/workflows/tests_eessi_module.yml
+++ b/.github/workflows/tests_eessi_module.yml
@@ -218,11 +218,17 @@ jobs:
           # Do (and undo) loading the EESSI module
           CPU_ARCH=$(./init/eessi_archdetect.sh -a cpupath)
           module load EESSI/${{matrix.EESSI_VERSION}}
-          # We create this dir the the verify_eessi_environment.py later on, since the EESSI_SITE_MODULEPATH_ACCEL
-          # will only be set if this dir exists - and we can most easily create it here, where we have
-          # EESSI_SITE_SOFTWARE_PATH and EESSI_ACCEL_SOFTWARE_SUBDIR available
+          # EESSI_SITE_MODULEPATH_ACCEL will only be set if this dir exists. We can most easily create it here
+          # where we have EESSI_SITE_SOFTWARE_PATH and EESSI_ACCEL_SOFTWARE_SUBDIR available
+          # Creating it here means the verify_eessi_environment.py can later on check that EESSI_SITE_MODULEPATH_ACCEL
+          # is set correctly
+          # First, we need to get the modules subdir. For this we strip EESSI_SITE_SOFTWARE_PATH from the start of
+          # EESSI_SITE_MODULEPATH
+          eessi_modules_subdir=${EESSI_SITE_MODULEPATH/$EESSI_SITE_SOFTWARE_PATH\//}
+          # Then, we make sure the target of /cvmfs/software.eessi.io/host_injections exists (or the 2nd mkdir fails)
           mkdir -p /opt/eessi
-          mkdir -p -v "$EESSI_SITE_SOFTWARE_PATH/$EESSI_ACCEL_SUBDIR"
+          # Then, we actually create the dir
+          mkdir -p -v "$EESSI_SITE_SOFTWARE_PATH/$EESSI_ACCEL_SUBDIR/$eessi_modules_subdir"
           module unload EESSI/${{matrix.EESSI_VERSION}}
           env | grep -v _ModuleTable | sort > "${module_cycled_file}"
 

--- a/.github/workflows/tests_eessi_module.yml
+++ b/.github/workflows/tests_eessi_module.yml
@@ -227,8 +227,9 @@ jobs:
           eessi_modules_subdir=${EESSI_SITE_MODULEPATH/$EESSI_SITE_SOFTWARE_PATH\//}
           # Then, we make sure the target of /cvmfs/software.eessi.io/host_injections exists (or the 2nd mkdir fails)
           mkdir -p /opt/eessi
-          # Then, we actually create the dir
-          mkdir -p -v "$EESSI_SITE_SOFTWARE_PATH/$EESSI_ACCEL_SUBDIR/$eessi_modules_subdir"
+          # Then, we actually create the dir. Note that we use EESSI_ACCEL_TARGET, as this represents the target
+          # _after_ any fallbacks
+          mkdir -p -v "$EESSI_SITE_SOFTWARE_PATH/$EESSI_ACCEL_TARGET/$eessi_modules_subdir"
           module unload EESSI/${{matrix.EESSI_VERSION}}
           env | grep -v _ModuleTable | sort > "${module_cycled_file}"
 

--- a/.github/workflows/tests_eessi_module.yml
+++ b/.github/workflows/tests_eessi_module.yml
@@ -218,6 +218,10 @@ jobs:
           # Do (and undo) loading the EESSI module
           CPU_ARCH=$(./init/eessi_archdetect.sh -a cpupath)
           module load EESSI/${{matrix.EESSI_VERSION}}
+          # We create this dir the the verify_eessi_environment.py later on, since the EESSI_SITE_MODULEPATH_ACCEL
+          # will only be set if this dir exists - and we can most easily create it here, where we have
+          # EESSI_SITE_SOFTWARE_PATH and EESSI_ACCEL_SOFTWARE_SUBDIR available
+          mkdir -p $EESSI_SITE_SOFTWARE_PATH/$EESSI_ACCEL_SOFTWARE_SUBDIR
           module unload EESSI/${{matrix.EESSI_VERSION}}
           env | grep -v _ModuleTable | sort > "${module_cycled_file}"
 

--- a/.github/workflows/tests_eessi_module.yml
+++ b/.github/workflows/tests_eessi_module.yml
@@ -227,9 +227,9 @@ jobs:
           eessi_modules_subdir=${EESSI_SITE_MODULEPATH/$EESSI_SITE_SOFTWARE_PATH\//}
           # Then, we make sure the target of /cvmfs/software.eessi.io/host_injections exists (or the 2nd mkdir fails)
           mkdir -p /opt/eessi
-          # Then, we actually create the dir. Note that we use EESSI_ACCEL_TARGET, as this represents the target
+          # Then, we actually create the dir. Note that we use EESSI_ACCELERATOR_TARGET, as this represents the target
           # _after_ any fallbacks
-          mkdir -p -v "$EESSI_SITE_SOFTWARE_PATH/$EESSI_ACCEL_TARGET/$eessi_modules_subdir"
+          mkdir -p -v "$EESSI_SITE_SOFTWARE_PATH/$EESSI_ACCELERATOR_TARGET/$eessi_modules_subdir"
           module unload EESSI/${{matrix.EESSI_VERSION}}
           env | grep -v _ModuleTable | sort > "${module_cycled_file}"
 

--- a/.github/workflows/tests_eessi_module.yml
+++ b/.github/workflows/tests_eessi_module.yml
@@ -221,11 +221,8 @@ jobs:
           # We create this dir the the verify_eessi_environment.py later on, since the EESSI_SITE_MODULEPATH_ACCEL
           # will only be set if this dir exists - and we can most easily create it here, where we have
           # EESSI_SITE_SOFTWARE_PATH and EESSI_ACCEL_SOFTWARE_SUBDIR available
-          # DEBUG OUTPUT:
-          ls -al /cvmfs/software.eessi.io/host_injections
           mkdir -p /opt/eessi
-          ls -al /cvmfs/software.eessi.io/host_injections
-          mkdir -p "$EESSI_SITE_SOFTWARE_PATH/$EESSI_ACCEL_SUBDIR"
+          mkdir -p -v "$EESSI_SITE_SOFTWARE_PATH/$EESSI_ACCEL_SUBDIR"
           module unload EESSI/${{matrix.EESSI_VERSION}}
           env | grep -v _ModuleTable | sort > "${module_cycled_file}"
 

--- a/.github/workflows/tests_eessi_module.yml
+++ b/.github/workflows/tests_eessi_module.yml
@@ -221,7 +221,7 @@ jobs:
           # We create this dir the the verify_eessi_environment.py later on, since the EESSI_SITE_MODULEPATH_ACCEL
           # will only be set if this dir exists - and we can most easily create it here, where we have
           # EESSI_SITE_SOFTWARE_PATH and EESSI_ACCEL_SOFTWARE_SUBDIR available
-          mkdir -p $EESSI_SITE_SOFTWARE_PATH/$EESSI_ACCEL_SOFTWARE_SUBDIR
+          mkdir -p $EESSI_SITE_SOFTWARE_PATH/$EESSI_ACCEL_SUBDIR
           module unload EESSI/${{matrix.EESSI_VERSION}}
           env | grep -v _ModuleTable | sort > "${module_cycled_file}"
 

--- a/init/bash
+++ b/init/bash
@@ -35,7 +35,7 @@ if [ $? -eq 0 ]; then
     show_msg "Prepending site path $EESSI_SITE_MODULEPATH to \$MODULEPATH..."
     module use $EESSI_SITE_MODULEPATH
 
-    if [ ! -z ${EESSI_MODULEPATH_ACCEL} ]; then
+    if [ ! -z ${EESSI_SITE_MODULEPATH_ACCEL} ]; then
         show_msg "Prepending $EESSI_SITE_MODULEPATH_ACCEL to \$MODULEPATH..."
         module use $EESSI_SITE_MODULEPATH_ACCEL
     fi

--- a/init/eessi_environment_variables
+++ b/init/eessi_environment_variables
@@ -119,7 +119,20 @@ if [ -d $EESSI_PREFIX ]; then
         if [ ! -z $EESSI_BASIC_ENV ]; then
           show_msg "Only setting up basic environment, so we're done"
         elif [ -d $EESSI_SOFTWARE_PATH ]; then
-          export EESSI_SITE_SOFTWARE_PATH=${EESSI_SOFTWARE_PATH/versions/host_injections}
+          if [ -z ${EESSI_SITE_SOFTWARE_PREFIX} ]; then
+            site_software_path=${EESSI_SOFTWARE_PATH/versions/host_injections}
+          else
+            site_software_path=${EESSI_SOFTWARE_PATH/$EESSI_SITE_SOFTWARE_PREFIX/$EESSI_CVMFS_REPO}
+          fi
+          export EESSI_SITE_SOFTWARE_PATH=${site_software_path}
+          # Prepend site's lmodrc.lua path to $LMOD_RC
+          show_msg "Adding Lmod site configuration file path ($site_lmod_rc_file) to $LMOD_RC"
+          site_lmod_rc_file="$EESSI_SITE_SOFTWARE_PATH/.lmod/lmodrc.lua"
+          if [ -z ${LMOD_RC} ]; then
+            export LMOD_RC=$site_lmod_rc_file
+          else
+            export LMOD_RC=$site_lmod_rc_file:$LMOD_RC
+          fi
           show_msg "Using ${EESSI_SITE_SOFTWARE_PATH} as the site extension directory for installations."
           EESSI_SITE_ACCEL_SOFTWARE_PATH=${EESSI_ACCEL_SOFTWARE_PATH/versions/host_injections}
           show_msg "Using ${EESSI_SITE_ACCEL_SOFTWARE_PATH} as the site extension directory for accelerated installations."

--- a/init/eessi_environment_variables
+++ b/init/eessi_environment_variables
@@ -121,11 +121,16 @@ if [ -d "$EESSI_PREFIX" ]; then
         elif [ -d "$EESSI_SOFTWARE_PATH" ]; then
           if [ -z "${EESSI_SITE_SOFTWARE_PREFIX}" ]; then
             site_software_path="${EESSI_SOFTWARE_PATH/versions/host_injections}"
+            site_software_accel_path="${EESSI_ACCEL_SOFTWARE_PATH/versions/host_injections}"
           else
             site_software_path="${EESSI_SOFTWARE_PATH/$EESSI_SITE_SOFTWARE_PREFIX/$EESSI_CVMFS_REPO}"
+            site_software_accel_path="${EESSI_ACCEL_SOFTWARE_PATH/$EESSI_SITE_SOFTWARE_PREFIX/$EESSI_CVMFS_REPO}"
           fi
           export EESSI_SITE_SOFTWARE_PATH="${site_software_path}"
-          show_msg "Set the site software path to $EESSI_SITE_SOFTWARE_PATH"
+          EESSI_SITE_ACCEL_SOFTWARE_PATH="${site_software_accel_path}"
+          show_msg "Using ${EESSI_SITE_SOFTWARE_PATH} as the site extension directory for installations."
+          show_msg "Using ${EESSI_SITE_ACCEL_SOFTWARE_PATH} as the site extension directory for accelerated installations."
+
           # Prepend site's lmodrc.lua path to $LMOD_RC
           show_msg "Adding Lmod site configuration file path ($site_lmod_rc_file) to $LMOD_RC"
           site_lmod_rc_file="$EESSI_SITE_SOFTWARE_PATH/.lmod/lmodrc.lua"
@@ -134,9 +139,6 @@ if [ -d "$EESSI_PREFIX" ]; then
           else
             export LMOD_RC="$site_lmod_rc_file:$LMOD_RC"
           fi
-          show_msg "Using ${EESSI_SITE_SOFTWARE_PATH} as the site extension directory for installations."
-          EESSI_SITE_ACCEL_SOFTWARE_PATH="${EESSI_ACCEL_SOFTWARE_PATH/versions/host_injections}"
-          show_msg "Using ${EESSI_SITE_ACCEL_SOFTWARE_PATH} as the site extension directory for accelerated installations."
           # Allow for use of alternative module tree shipped with EESSI
           if [ -z ${EESSI_MODULE_SUBDIR+x} ]; then
             # EESSI_MODULE_SUBDIR not set

--- a/init/eessi_environment_variables
+++ b/init/eessi_environment_variables
@@ -18,11 +18,11 @@ function show_msg {
 # set up minimal environment: $EESSI_PREFIX, $EESSI_VERSION, $EESSI_OS_TYPE, $EESSI_CPU_FAMILY, $EPREFIX
 source $EESSI_INIT_DIR_PATH/minimal_eessi_env
 
-if [ -d $EESSI_PREFIX ]; then
+if [ -d "$EESSI_PREFIX" ]; then
   show_msg "Found EESSI repo @ $EESSI_PREFIX!"
 
-  export EESSI_EPREFIX=$EPREFIX
-  if [ -d $EESSI_EPREFIX ]; then
+  export EESSI_EPREFIX="$EPREFIX"
+  if [ -d "$EESSI_EPREFIX" ]; then
 
     # determine subdirectory in software layer
     if [ "$EESSI_USE_ARCHDETECT" == "1" ]; then
@@ -32,8 +32,8 @@ if [ -d $EESSI_PREFIX ]; then
       #   under $EESSI_PREFIX/software/$EESSI_OS_TYPE; if so use the architecture as best match
       IFS=: read -r -a archs <<< "${all_cpupaths}"
       for arch in "${archs[@]}"; do
-        if [ -d ${EESSI_PREFIX}/software/${EESSI_OS_TYPE}/${arch} ]; then
-          export EESSI_SOFTWARE_SUBDIR=${arch}
+        if [ -d "${EESSI_PREFIX}/software/${EESSI_OS_TYPE}/${arch}" ]; then
+          export EESSI_SOFTWARE_SUBDIR="${arch}"
           show_msg "archdetect says ${EESSI_SOFTWARE_SUBDIR}"
           break
         fi
@@ -58,23 +58,23 @@ if [ -d $EESSI_PREFIX ]; then
         set -e
       fi
 
-      if [[ $accelpath_exit_code -eq 0 ]]; then
+      if [[ "$accelpath_exit_code" -eq 0 ]]; then
           export EESSI_ACCEL_SUBDIR=$(tail -n 1 $tmpout && rm -f $tmpout)
-          if [ -z ${EESSI_ACCEL_SUBDIR} ]; then
+          if [ -z "${EESSI_ACCEL_SUBDIR}" ]; then
               error "accelerator detection with archdetect worked, but no result was returned?!"
           else
               # allow specifying different parent directory for accel/* subdirectory via $EESSI_ACCEL_SOFTWARE_SUBDIR_OVERRIDE
-              EESSI_ACCEL_SOFTWARE_SUBDIR=${EESSI_ACCEL_SOFTWARE_SUBDIR_OVERRIDE:-$EESSI_SOFTWARE_SUBDIR}
+              EESSI_ACCEL_SOFTWARE_SUBDIR="${EESSI_ACCEL_SOFTWARE_SUBDIR_OVERRIDE:-$EESSI_SOFTWARE_SUBDIR}"
               # path to where accel/* subdirectory is located
-              EESSI_ACCEL_SOFTWARE_PATH=${EESSI_PREFIX}/software/${EESSI_OS_TYPE}/${EESSI_ACCEL_SOFTWARE_SUBDIR}
-              if [ ! -d $EESSI_ACCEL_SOFTWARE_PATH/${EESSI_ACCEL_SUBDIR} ]; then
+              EESSI_ACCEL_SOFTWARE_PATH="${EESSI_PREFIX}/software/${EESSI_OS_TYPE}/${EESSI_ACCEL_SOFTWARE_SUBDIR}"
+              if [ ! -d "$EESSI_ACCEL_SOFTWARE_PATH/${EESSI_ACCEL_SUBDIR}" ]; then
                   # We should try to use the fallback compute capability
                   EESSI_ACCELERATOR_TARGET="${EESSI_ACCEL_SUBDIR::-1}0"
                   show_msg "archdetect found no supported accelerator ${EESSI_ACCEL_SUBDIR}, falling back to ${EESSI_ACCELERATOR_TARGET}"
               else
                   EESSI_ACCELERATOR_TARGET="${EESSI_ACCEL_SUBDIR}"
               fi
-              if [ -d $EESSI_ACCEL_SOFTWARE_PATH/${EESSI_ACCELERATOR_TARGET} ]; then
+              if [ -d "$EESSI_ACCEL_SOFTWARE_PATH/${EESSI_ACCELERATOR_TARGET}" ]; then
                   show_msg "archdetect found supported accelerator for CPU target ${EESSI_ACCEL_SOFTWARE_SUBDIR}: ${EESSI_ACCELERATOR_TARGET}"
                   export EESSI_ACCELERATOR_TARGET
               else
@@ -83,7 +83,7 @@ if [ -d $EESSI_PREFIX ]; then
           fi
       else
           show_msg "archdetect could not detect any accelerators"
-          rm -f $tmpout
+          rm -f "$tmpout"
       fi
     elif [ "$EESSI_USE_ARCHSPEC" == "1" ]; then
       # note: eessi_software_subdir_for_host.py will pick up value from $EESSI_SOFTWARE_SUBDIR_OVERRIDE if it's defined!
@@ -93,15 +93,15 @@ if [ -d $EESSI_PREFIX ]; then
     else
       error "Don't know how to detect host CPU, giving up!"
     fi
-    if [ ! -z $EESSI_SOFTWARE_SUBDIR ]; then
+    if [ ! -z "$EESSI_SOFTWARE_SUBDIR" ]; then
 
         show_msg "Using ${EESSI_SOFTWARE_SUBDIR} as software subdirectory."
-        export EESSI_SOFTWARE_PATH=$EESSI_PREFIX/software/$EESSI_OS_TYPE/$EESSI_SOFTWARE_SUBDIR
+        export EESSI_SOFTWARE_PATH="$EESSI_PREFIX/software/$EESSI_OS_TYPE/$EESSI_SOFTWARE_SUBDIR"
 
         # Configure our LMOD
         export LMOD_CONFIG_DIR="$EESSI_SOFTWARE_PATH/.lmod"
         lmod_rc_file="$LMOD_CONFIG_DIR/lmodrc.lua"
-        if [ -f $lmod_rc_file ]; then
+        if [ -f "$lmod_rc_file" ]; then
           show_msg "Found Lmod configuration file at $lmod_rc_file"
           export LMOD_RC="$lmod_rc_file"
         else
@@ -110,31 +110,31 @@ if [ -d $EESSI_PREFIX ]; then
 
         export LMOD_PACKAGE_PATH="$EESSI_SOFTWARE_PATH/.lmod"
         lmod_sitepackage_file="$LMOD_PACKAGE_PATH/SitePackage.lua"
-        if [ -f $lmod_sitepackage_file ]; then
+        if [ -f "$lmod_sitepackage_file" ]; then
           show_msg "Found Lmod SitePackage.lua file at $lmod_sitepackage_file"
         else
           error "Lmod SitePackage.lua file not found at $lmod_sitepackage_file"
         fi
        
-        if [ ! -z $EESSI_BASIC_ENV ]; then
+        if [ ! -z "$EESSI_BASIC_ENV" ]; then
           show_msg "Only setting up basic environment, so we're done"
-        elif [ -d $EESSI_SOFTWARE_PATH ]; then
-          if [ -z ${EESSI_SITE_SOFTWARE_PREFIX} ]; then
-            site_software_path=${EESSI_SOFTWARE_PATH/versions/host_injections}
+        elif [ -d "$EESSI_SOFTWARE_PATH" ]; then
+          if [ -z "${EESSI_SITE_SOFTWARE_PREFIX}" ]; then
+            site_software_path="${EESSI_SOFTWARE_PATH/versions/host_injections}"
           else
-            site_software_path=${EESSI_SOFTWARE_PATH/$EESSI_SITE_SOFTWARE_PREFIX/$EESSI_CVMFS_REPO}
+            site_software_path="${EESSI_SOFTWARE_PATH/$EESSI_SITE_SOFTWARE_PREFIX/$EESSI_CVMFS_REPO}"
           fi
-          export EESSI_SITE_SOFTWARE_PATH=${site_software_path}
+          export EESSI_SITE_SOFTWARE_PATH="${site_software_path}"
           # Prepend site's lmodrc.lua path to $LMOD_RC
           show_msg "Adding Lmod site configuration file path ($site_lmod_rc_file) to $LMOD_RC"
           site_lmod_rc_file="$EESSI_SITE_SOFTWARE_PATH/.lmod/lmodrc.lua"
-          if [ -z ${LMOD_RC} ]; then
-            export LMOD_RC=$site_lmod_rc_file
+          if [ -z "${LMOD_RC}" ]; then
+            export LMOD_RC="$site_lmod_rc_file"
           else
-            export LMOD_RC=$site_lmod_rc_file:$LMOD_RC
+            export LMOD_RC="$site_lmod_rc_file:$LMOD_RC"
           fi
           show_msg "Using ${EESSI_SITE_SOFTWARE_PATH} as the site extension directory for installations."
-          EESSI_SITE_ACCEL_SOFTWARE_PATH=${EESSI_ACCEL_SOFTWARE_PATH/versions/host_injections}
+          EESSI_SITE_ACCEL_SOFTWARE_PATH="${EESSI_ACCEL_SOFTWARE_PATH/versions/host_injections}"
           show_msg "Using ${EESSI_SITE_ACCEL_SOFTWARE_PATH} as the site extension directory for accelerated installations."
           # Allow for use of alternative module tree shipped with EESSI
           if [ -z ${EESSI_MODULE_SUBDIR+x} ]; then
@@ -145,26 +145,26 @@ if [ -d $EESSI_PREFIX ]; then
           if [ -z ${EESSI_CUSTOM_MODULEPATH+x} ]; then
             # EESSI_CUSTOM_MODULEPATH not set so we use our defaults
 
-            EESSI_MODULEPATH=$EESSI_SOFTWARE_PATH/$EESSI_MODULE_SUBDIR
+            EESSI_MODULEPATH="$EESSI_SOFTWARE_PATH/$EESSI_MODULE_SUBDIR"
           else
             show_msg "Using defined environment variable \$EESSI_CUSTOM_MODULEPATH to set EESSI_MODULEPATH."
-            EESSI_MODULEPATH=$EESSI_CUSTOM_MODULEPATH
+            EESSI_MODULEPATH="$EESSI_CUSTOM_MODULEPATH"
           fi
 
-          if [ -d $EESSI_MODULEPATH ]; then
-            export EESSI_MODULEPATH=$EESSI_MODULEPATH
+          if [ -d "$EESSI_MODULEPATH" ]; then
+            export EESSI_MODULEPATH="$EESSI_MODULEPATH"
             show_msg "Using ${EESSI_MODULEPATH} as the directory to be added to MODULEPATH."
-            export EESSI_SITE_MODULEPATH=$EESSI_SITE_SOFTWARE_PATH/$EESSI_MODULE_SUBDIR
+            export EESSI_SITE_MODULEPATH="$EESSI_SITE_SOFTWARE_PATH/$EESSI_MODULE_SUBDIR"
             show_msg "Using ${EESSI_SITE_MODULEPATH} as the site extension directory to be added to MODULEPATH."
           else
             error "EESSI module path at $EESSI_MODULEPATH not found!"
             false
           fi
 
-          if [ -d ${EESSI_ACCEL_SOFTWARE_PATH}/${EESSI_ACCELERATOR_TARGET}/${EESSI_MODULE_SUBDIR} ]; then
-              export EESSI_MODULEPATH_ACCEL=${EESSI_ACCEL_SOFTWARE_PATH}/${EESSI_ACCELERATOR_TARGET}/${EESSI_MODULE_SUBDIR}
+          if [ -d "${EESSI_ACCEL_SOFTWARE_PATH}/${EESSI_ACCELERATOR_TARGET}/${EESSI_MODULE_SUBDIR}" ]; then
+              export EESSI_MODULEPATH_ACCEL="${EESSI_ACCEL_SOFTWARE_PATH}/${EESSI_ACCELERATOR_TARGET}/${EESSI_MODULE_SUBDIR}"
               show_msg "Using ${EESSI_MODULEPATH_ACCEL} as additional directory (for accelerators) to be added to MODULEPATH."
-              export EESSI_SITE_MODULEPATH_ACCEL=${EESSI_SITE_ACCEL_SOFTWARE_PATH}/${EESSI_ACCELERATOR_TARGET}/${EESSI_MODULE_SUBDIR}
+              export EESSI_SITE_MODULEPATH_ACCEL="${EESSI_SITE_ACCEL_SOFTWARE_PATH}/${EESSI_ACCELERATOR_TARGET}/${EESSI_MODULE_SUBDIR}"
               show_msg "Using ${EESSI_SITE_MODULEPATH_ACCEL} as additional site extension directory (for accelerators) to be added to MODULEPATH."
           fi
 
@@ -173,9 +173,9 @@ if [ -d $EESSI_PREFIX ]; then
           # curl as a module file we could instead do this via a `modluafooter` in an EasyBuild
           # hook (or via an Lmod hook)
           rhel_libcurl_file="/etc/pki/tls/certs/ca-bundle.crt"
-          if [ -f $rhel_libcurl_file ]; then
+          if [ -f "$rhel_libcurl_file" ]; then
             show_msg "Found libcurl CAs file at RHEL location, setting CURL_CA_BUNDLE"
-            export CURL_CA_BUNDLE=$rhel_libcurl_file
+            export CURL_CA_BUNDLE="$rhel_libcurl_file"
           fi
 
         else

--- a/init/eessi_environment_variables
+++ b/init/eessi_environment_variables
@@ -167,6 +167,8 @@ if [ -d "$EESSI_PREFIX" ]; then
           if [ -d "${EESSI_ACCEL_SOFTWARE_PATH}/${EESSI_ACCELERATOR_TARGET}/${EESSI_MODULE_SUBDIR}" ]; then
               export EESSI_MODULEPATH_ACCEL="${EESSI_ACCEL_SOFTWARE_PATH}/${EESSI_ACCELERATOR_TARGET}/${EESSI_MODULE_SUBDIR}"
               show_msg "Using ${EESSI_MODULEPATH_ACCEL} as additional directory (for accelerators) to be added to MODULEPATH."
+          fi
+          if [ -d "${EESSI_SITE_ACCEL_SOFTWARE_PATH}/${EESSI_ACCELERATOR_TARGET}/${EESSI_MODULE_SUBDIR}" ]; then
               export EESSI_SITE_MODULEPATH_ACCEL="${EESSI_SITE_ACCEL_SOFTWARE_PATH}/${EESSI_ACCELERATOR_TARGET}/${EESSI_MODULE_SUBDIR}"
               show_msg "Using ${EESSI_SITE_MODULEPATH_ACCEL} as additional site extension directory (for accelerators) to be added to MODULEPATH."
           fi

--- a/init/eessi_environment_variables
+++ b/init/eessi_environment_variables
@@ -125,6 +125,7 @@ if [ -d "$EESSI_PREFIX" ]; then
             site_software_path="${EESSI_SOFTWARE_PATH/$EESSI_SITE_SOFTWARE_PREFIX/$EESSI_CVMFS_REPO}"
           fi
           export EESSI_SITE_SOFTWARE_PATH="${site_software_path}"
+          show_msg "Set the site software path to $EESSI_SITE_SOFTWARE_PATH"
           # Prepend site's lmodrc.lua path to $LMOD_RC
           show_msg "Adding Lmod site configuration file path ($site_lmod_rc_file) to $LMOD_RC"
           site_lmod_rc_file="$EESSI_SITE_SOFTWARE_PATH/.lmod/lmodrc.lua"

--- a/init/eessi_environment_variables
+++ b/init/eessi_environment_variables
@@ -123,12 +123,12 @@ if [ -d "$EESSI_PREFIX" ]; then
             site_software_path="${EESSI_SOFTWARE_PATH/versions/host_injections}"
             site_software_accel_path="${EESSI_ACCEL_SOFTWARE_PATH/versions/host_injections}"
           else
-            site_software_path="${EESSI_SOFTWARE_PATH/$EESSI_SITE_SOFTWARE_PREFIX/$EESSI_CVMFS_REPO}"
-            site_software_accel_path="${EESSI_ACCEL_SOFTWARE_PATH/$EESSI_SITE_SOFTWARE_PREFIX/$EESSI_CVMFS_REPO}"
+            site_software_path="${EESSI_SOFTWARE_PATH/$EESSI_CVMFS_REPO/$EESSI_SITE_SOFTWARE_PREFIX}"
+            site_software_accel_path="${EESSI_ACCEL_SOFTWARE_PATH/$EESSI_CVMFS_REPO/$EESSI_SITE_SOFTWARE_PREFIX}"
           fi
           export EESSI_SITE_SOFTWARE_PATH="${site_software_path}"
-          EESSI_SITE_ACCEL_SOFTWARE_PATH="${site_software_accel_path}"
           show_msg "Using ${EESSI_SITE_SOFTWARE_PATH} as the site extension directory for installations."
+          EESSI_SITE_ACCEL_SOFTWARE_PATH="${site_software_accel_path}"
           show_msg "Using ${EESSI_SITE_ACCEL_SOFTWARE_PATH} as the site extension directory for accelerated installations."
 
           # Prepend site's lmodrc.lua path to $LMOD_RC

--- a/init/modules/EESSI/2023.06.lua
+++ b/init/modules/EESSI/2023.06.lua
@@ -140,7 +140,7 @@ local eessi_site_software_path
 -- If it is not defined, default to a site installation prefix under host_injections
 site_prefix = os.getenv("EESSI_SITE_SOFTWARE_PREFIX")
 if site_prefix then
-    eessi_site_software_path = string.gsub(eessi_software_path, os.getenv("EESSI_CVMFS_REPO"), site_prefix)
+    eessi_site_software_path = string.gsub(eessi_software_path, eessi_repo, site_prefix)
 else
     eessi_site_software_path = string.gsub(eessi_software_path, "versions", "host_injections")
 end

--- a/init/modules/EESSI/2023.06.lua
+++ b/init/modules/EESSI/2023.06.lua
@@ -225,8 +225,17 @@ end
 -- prepend the site module path last so it has priority
 prepend_path("MODULEPATH", eessi_site_module_path)
 eessiDebug("Adding " .. eessi_site_module_path .. " to MODULEPATH")
-if isDir(eessi_module_path_accel) then
+
+-- If EESSI_SITE_SOFTWARE_PREFIX is defined, replace /cvmfs/software.eessi.io (or more generally EESSI_CVMFS_REPO)
+-- by that prefix to get the site accelerator path. This ensures that the directory still contains the 
+-- os/vendor/arch/micro-arch/accelerator etc. If it is not defined, default to a site installation prefix under
+-- host_injections
+if site_prefix then
+    eessi_module_path_site_accel = string.gsub(eessi_module_path_accel, eessi_repo, site_prefix)
+else
     eessi_module_path_site_accel = string.gsub(eessi_module_path_accel, "versions", "host_injections")
+end
+if isDir(eessi_module_path_site_accel) then
     setenv("EESSI_SITE_MODULEPATH_ACCEL", eessi_module_path_site_accel)
     prepend_path("MODULEPATH", eessi_module_path_site_accel)
     eessiDebug("Using site accelerator modules at: " .. eessi_module_path_site_accel)

--- a/init/modules/EESSI/2023.06.lua
+++ b/init/modules/EESSI/2023.06.lua
@@ -125,7 +125,16 @@ local eessi_modules_subdir = pathJoin("modules", "all")
 -- eessi_module_path is the location of the _CPU_ module files, e.g.,
 -- /cvmfs/software.eessi.io/versions/<EESSI_VERSION>/software/linux/x86_64/amd/zen3/modules/all
 local eessi_module_path = pathJoin(eessi_software_path, eessi_modules_subdir)
-local eessi_site_software_path = string.gsub(eessi_software_path, "versions", "host_injections")
+local eessi_site_software_path
+-- If EESSI_SITE_SOFTWARE_PREFIX is defined, replace /cvmfs/software.eessi.io (or more generally EESSI_CVMFS_REPO)
+-- by that prefix. This ensures that the directory still contains the os/vendor/arch/micro-arch/accelerator etc
+-- If it is not defined, default to a site installation prefix under host_injections
+site_prefix = os.getenv("EESSI_SITE_SOFTWARE_PREFIX")
+if site_prefix then
+    eessi_site_software_path = string.gsub(eessi_software_path, os.getenv("EESSI_CVMFS_REPO"), site_prefix)
+else
+    eessi_site_software_path = string.gsub(eessi_software_path, "versions", "host_injections")
+end
 -- Site module path is the same as the EESSI one, but with `versions` changed to `host_injections`, e.g.,
 --  /cvmfs/software.eessi.io/host_injections/<EESSI_VERSION>/software/linux/x86_64/amd/zen3/modules/all
 local eessi_site_module_path = pathJoin(eessi_site_software_path, eessi_modules_subdir)
@@ -160,8 +169,14 @@ if ( mode() ~= "spider" ) then
     prepend_path("MODULEPATH", eessi_module_path)
     eessiDebug("Adding " .. eessi_module_path .. " to MODULEPATH")
 end
+
+-- Make sure the EESSI cache is found, this is specified in the lmodrc.lua in the eessi_software_path
 prepend_path("LMOD_RC", pathJoin(eessi_software_path, ".lmod", "lmodrc.lua"))
 eessiDebug("Adding " .. pathJoin(eessi_software_path, ".lmod", "lmodrc.lua") .. " to LMOD_RC")
+-- Make sure that a cache for site installations can also be found
+prepend_path("LMOD_RC", pathJoin(eessi_site_software_path , ".lmod", "lmodrc.lua"))
+eessiDebug("Adding " .. pathJoin(eessi_site_software_path , ".lmod", "lmodrc.lua") .. " to LMOD_RC")
+
 -- Use pushenv for LMOD_PACKAGE_PATH as this may be set locally by the site
 pushenv("LMOD_PACKAGE_PATH", pathJoin(eessi_software_path, ".lmod"))
 eessiDebug("Setting LMOD_PACKAGE_PATH to " .. pathJoin(eessi_software_path, ".lmod"))

--- a/init/modules/EESSI/2023.06.lua
+++ b/init/modules/EESSI/2023.06.lua
@@ -230,7 +230,7 @@ eessiDebug("Adding " .. eessi_site_module_path .. " to MODULEPATH")
 -- by that prefix to get the site accelerator path. This ensures that the directory still contains the 
 -- os/vendor/arch/micro-arch/accelerator etc. If it is not defined, default to a site installation prefix under
 -- host_injections
-if site_prefix then
+if site_prefix and eessi_module_path_accel then
     eessi_module_path_site_accel = string.gsub(eessi_module_path_accel, eessi_repo, site_prefix)
 else
     eessi_module_path_site_accel = string.gsub(eessi_module_path_accel, "versions", "host_injections")

--- a/init/modules/EESSI/2023.06.lua
+++ b/init/modules/EESSI/2023.06.lua
@@ -230,15 +230,18 @@ eessiDebug("Adding " .. eessi_site_module_path .. " to MODULEPATH")
 -- by that prefix to get the site accelerator path. This ensures that the directory still contains the 
 -- os/vendor/arch/micro-arch/accelerator etc. If it is not defined, default to a site installation prefix under
 -- host_injections
-if site_prefix and eessi_module_path_accel then
-    eessi_module_path_site_accel = string.gsub(eessi_module_path_accel, eessi_repo, site_prefix)
-else
-    eessi_module_path_site_accel = string.gsub(eessi_module_path_accel, "versions", "host_injections")
-end
-if isDir(eessi_module_path_site_accel) then
-    setenv("EESSI_SITE_MODULEPATH_ACCEL", eessi_module_path_site_accel)
-    prepend_path("MODULEPATH", eessi_module_path_site_accel)
-    eessiDebug("Using site accelerator modules at: " .. eessi_module_path_site_accel)
+-- Note that we need the eessi_module_path_accel to construct either of these site installation accelerator paths
+if eessi_module_path_accel then
+    if site_prefix then
+        eessi_module_path_site_accel = string.gsub(eessi_module_path_accel, eessi_repo, site_prefix)
+    else
+        eessi_module_path_site_accel = string.gsub(eessi_module_path_accel, "versions", "host_injections")
+    end
+    if isDir(eessi_module_path_site_accel) then
+        setenv("EESSI_SITE_MODULEPATH_ACCEL", eessi_module_path_site_accel)
+        prepend_path("MODULEPATH", eessi_module_path_site_accel)
+        eessiDebug("Using site accelerator modules at: " .. eessi_module_path_site_accel)
+    end
 end
 
 -- allow sites to add a family directive to the EESSI module,


### PR DESCRIPTION
This is preparatory work for better supporting building on top of EESSI. 

Specifically, this change allows sites to customize where their site installation path is through `EESSI_SITE_SOFTWARE_PREFIX`. It also makes sure that any caches for the site-installs are picked up by adding the `lmodrc` file to the `LDOD_RC` search path. Thus, as long as sites generate an `lmodrc.lua` (e.g. using the `create_lmodrc.py` from the `software-layer-scripts` repo) _and_ run the appropriate commands to generate a cache in the corresponding `.lmod` folder (analogous to how we do this for EESSI), this will allow them to also have a proper cache for locally installed modules.

An example would be:

```
[casparl@int5 software-layer-scripts]$ export EESSI_SITE_SOFTWARE_PREFIX=/foo/bar
[casparl@int5 software-layer-scripts]$ module load EESSI/2025.06
Module for EESSI/2025.06 loaded successfully
[casparl@int5 software-layer-scripts]$ echo $EESSI_SITE_SOFTWARE_PATH
/foo/bar/versions/2025.06/software/linux/x86_64/amd/zen2
[casparl@int5 software-layer-scripts]$ echo $MODULEPATH
/foo/bar/versions/2025.06/software/linux/x86_64/amd/zen2/modules/all:/cvmfs/software.eessi.io/versions/2025.06/software/linux/x86_64/amd/zen2/modules/all:/gpfs/home4/casparl/EESSI/software-layer-scripts/init/modules
[casparl@int5 software-layer-scripts]$ echo $LMOD_RC
/foo/bar/versions/2025.06/software/linux/x86_64/amd/zen2/.lmod/lmodrc.lua:/cvmfs/software.eessi.io/versions/2025.06/software/linux/x86_64/amd/zen2/.lmod/lmodrc.lua
```