### PR TITLE
use max. 6 cores for building libxc on A64FX, to increase available memory per core

### DIFF
--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -2032,7 +2032,7 @@ PARALLELISM_LIMITS = {
     # software-specific limits
     'libxc': {
         '*': (divide_by_factor, 2),
-        CPU_TARGET_A64FX: (set_maximum, 12),
+        CPU_TARGET_A64FX: (set_maximum, 6),
     },
     'LLVM': {
         '*': (divide_by_factor, 2),


### PR DESCRIPTION
follow-up for:
- #101

For `libxc-7.0.0-GCC-14.3.0.eb` (see https://github.com/EESSI/software-layer/pull/1502) , using 12 cores is not sufficient due to lack of sufficient memory, still results in build failure with:
```
gcc: fatal error: Killed signal terminated program cc1
```