### PR TITLE
Small change in EESSI-extend comment to allow redeployment on RISC-V

### DIFF
--- a/EESSI-extend-easybuild.eb
+++ b/EESSI-extend-easybuild.eb
@@ -133,7 +133,7 @@ if eessi_cvmfs_install then
     LmodError("You cannot use EESSI_CVMFS_INSTALL in combination with any other EESSI_*_INSTALL environment variables")
   end
   easybuild_installpath = os.getenv("EESSI_SOFTWARE_PATH")
-  -- enforce accelerator subdirectory usage for CVMFS installs (only if an accelerator install is requested)
+  -- Enforce accelerator subdirectory usage for CVMFS installs (only if an accelerator install is requested)
   if (eessi_accelerator_target ~= nil) and (cuda_compute_capability ~= nil or amd_compute_capability ~= nil) and (os.getenv("EESSI_ACCELERATOR_INSTALL") ~= nil) then
       easybuild_installpath = pathJoin(easybuild_installpath, eessi_accelerator_target)
   end
@@ -143,7 +143,7 @@ elseif eessi_site_install then
     LmodError("You cannot use EESSI_SITE_INSTALL in combination with any other EESSI_*_INSTALL environment variables")
   end
   easybuild_installpath = os.getenv("EESSI_SITE_SOFTWARE_PATH")
-  -- enforce accelerator subdirectory usage for site installs (only if an accelerator install is requested)
+  -- Enforce accelerator subdirectory usage for site installs (only if an accelerator install is requested)
   if (eessi_accelerator_target ~= nil) and (cuda_compute_capability ~= nil) and (os.getenv("EESSI_ACCELERATOR_INSTALL") ~= nil) then
       easybuild_installpath = pathJoin(easybuild_installpath, eessi_accelerator_target)
   end


### PR DESCRIPTION
The settings in the EESSI-extend module of the RISC-V repo are outdated, because it was never rebuilt after the initial installation. This leads to issues with for instance the CPP search path. Fixing it by forcing a redeploy here. In the future we should just always rebuild it for the RISC-V repo too.

