### PR TITLE
Log output of `ulimit -a` for every build

### DIFF
--- a/bot/build.sh
+++ b/bot/build.sh
@@ -195,7 +195,7 @@ echo "bot/build.sh: EESSI_ACCELERATOR_TARGET_OVERRIDE='${EESSI_ACCELERATOR_TARGE
 
 # Log the full lscpu, ulimits, and os-release info:
 lscpu > _bot_job${SLURM_JOB_ID}.lscpu
-ulimits -a > _bot_job${SLURM_JOB_ID}.ulimits
+ulimit -a > _bot_job${SLURM_JOB_ID}.ulimits
 cat /etc/os-release > _bot_job${SLURM_JOB_ID}.os
 
 # Also: fetch CPU flags into an array, so that we can implement a hard check against a reference

--- a/bot/build.sh
+++ b/bot/build.sh
@@ -193,8 +193,9 @@ else
 fi
 echo "bot/build.sh: EESSI_ACCELERATOR_TARGET_OVERRIDE='${EESSI_ACCELERATOR_TARGET_OVERRIDE}'"
 
-# Log the full lscpu and os-release info:
+# Log the full lscpu, ulimits, and os-release info:
 lscpu > _bot_job${SLURM_JOB_ID}.lscpu
+ulimits -a > _bot_job${SLURM_JOB_ID}.ulimits
 cat /etc/os-release > _bot_job${SLURM_JOB_ID}.os
 
 # Also: fetch CPU flags into an array, so that we can implement a hard check against a reference


### PR DESCRIPTION
Should make it easier to debug issues like #245 in the future.