### PR TITLE
Add a fallback version for EasyBuild in the EESSI-extend module

### DIFF
--- a/.github/workflows/tests_eessi_extend_module.yml
+++ b/.github/workflows/tests_eessi_extend_module.yml
@@ -50,9 +50,13 @@ jobs:
           export MY_INSTALLATION_PATH=/tmp/easybuild
           export EASYBUILD_PREFIX=$MY_INSTALLATION_PATH
           eb EESSI-extend-easybuild.eb --rebuild
+          module unload EasyBuild
 
           # Verify that we can pick the installed version up
           module use $MY_INSTALLATION_PATH/modules/all
+          # Verify we can run "module show" on the module
+          module show EESSI-extend/${{matrix.eessi_version}}-easybuild
+          # Now load it and run additional checks
           module load EESSI-extend/${{matrix.eessi_version}}-easybuild
           echo $EBROOTEESSIMINEXTEND | grep $MY_INSTALLATION_PATH || { echo "ERROR: Installed version of EESSI-extend not picked up (loaded $EBROOTEESSIMINEXTEND)" >&2; exit 1; }
           # Do a test rebuild (with default and local hooks)

--- a/EESSI-extend-easybuild.eb
+++ b/EESSI-extend-easybuild.eb
@@ -232,7 +232,8 @@ end
 
 -- Make sure EasyBuild itself is loaded
 -- need to also handle the unload behaviour where the version is defined only before we unload
-easybuild_version = os.getenv("EBVERSIONEASYBUILD")
+-- (also provide a sensible default for cases like 'module show' where the modules are never loaded at all)
+easybuild_version = os.getenv("EBVERSIONEASYBUILD") or "5.1.1"
 if not ( isloaded("EasyBuild") ) then
     load(latest("EasyBuild"))
 end


### PR DESCRIPTION
Without this change, you cannot run
```
module show EESSI-extend
```
unless you have an EasyBuild module loaded.