### PR TITLE
Make cfg_files.sh more robut in bash environment

### DIFF
--- a/scripts/cfg_files.sh
+++ b/scripts/cfg_files.sh
@@ -39,13 +39,13 @@ function cfg_load {
   local cur_val=""
   IFS=
   while read -r line; do
-    new_section=$(cfg_get_section $line)
+    new_section=$(cfg_get_section "${line}")
     # got a new section
     if [[ -n "$new_section" ]]; then
       cur_section=$new_section
     # not a section, try a key value
     else
-      val=$(cfg_get_key_value $line)
+      val=$(cfg_get_key_value "${line}")
       # trim leading and trailing spaces as well
       cur_key=$(echo $val | cut -f1 -d'=' | cfg_trim_spaces)
       cur_val=$(echo $val | cut -f2 -d'=' | cfg_trim_spaces)


### PR DESCRIPTION
This causes issues in environment where `shopt -s nullglob`. Which is the case for our local bot where we use cfg_files.sh. This small change will make the funtion a bit more robust.