### PR TITLE
Replace `rfoss` with `rocm-compilers` for EESSI 2025.06 for EasyBuild >= 5.3.0

### DIFF
--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -78,7 +78,7 @@ if EASYBUILD_VERSION >= '5.2.0':
 
 if EASYBUILD_VERSION >= '5.3.0':
     EESSI_SUPPORTED_TOP_LEVEL_TOOLCHAINS['2025.06'].append(
-        {'name': 'rfoss', 'version': '2025a'}
+        {'name': 'rocm-compilers', 'version': '19.0.0-ROCm-6.4.1'}
     )
 
 # Supported compute capabilities by CUDA toolkit version

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -78,7 +78,7 @@ if EASYBUILD_VERSION >= '5.2.0':
 
 if EASYBUILD_VERSION >= '5.3.0':
     EESSI_SUPPORTED_TOP_LEVEL_TOOLCHAINS['2025.06'].append(
-        {'name': 'rocm-compilers', 'version': '19.0.0-ROCm-6.4.1'}
+        {'name': 'rocm-compilers', 'version': '19.0.0'}
     )
 
 # Supported compute capabilities by CUDA toolkit version


### PR DESCRIPTION
`rfoss` and `rompi` easyconfigs have not been merged yet. 

This causes the EESSI build bot to throw an error: `Could not find easyconfig for rfoss toolchain version 2025a`.

Replacing `rfoss` with `rocm-compilers` will allow us to deploy easyconfigs built with `rocm-compilers` for now.

See: https://github.com/EESSI/software-layer/pull/1526#issuecomment-4732715358