### PR TITLE
Provide generic way to propagate env vars into startprefix environment

### DIFF
--- a/run_in_compat_layer_env.sh
+++ b/run_in_compat_layer_env.sh
@@ -72,9 +72,9 @@ fi
 # Example: PROPAGATE_INTO_PREFIX_FOO=bar => export FOO=bar
 while IFS='=' read -r var_name var_value; do
     # Only act on variables that start with the marker prefix
-    if [[ ${var_name} == PROPAGATE_INTO_PREFIX_* ]]; then
+    if [[ ${var_name} == EESSI_PROPAGATE_INTO_PREFIX_* ]]; then
         # Strip the marker prefix to obtain the target name
-        target_name=${var_name#PROPAGATE_INTO_PREFIX_}
+        target_name=${var_name#EESSI_PROPAGATE_INTO_PREFIX_}
         # Guard against empty target names
         if [[ -n ${target_name} ]]; then
             INPUT="export ${target_name}=${var_value}; ${INPUT}"

--- a/run_in_compat_layer_env.sh
+++ b/run_in_compat_layer_env.sh
@@ -66,6 +66,22 @@ if [ ! -z ${EESSI_SITE_INSTALL_FORCE} ]; then
     fi
 fi
 
+# The above propagates some hard-coded environment variables into the prefix environment
+# Here, we provide a mechanism that propagates ANY variable named PROPAGATE_INTO_PREFIX_<NAME>
+# into the prefix environment as "export <NAME>=<value>"
+# Example: PROPAGATE_INTO_PREFIX_FOO=bar => export FOO=bar
+while IFS='=' read -r var_name var_value; do
+    # Only act on variables that start with the marker prefix
+    if [[ ${var_name} == PROPAGATE_INTO_PREFIX_* ]]; then
+        # Strip the marker prefix to obtain the target name
+        target_name=${var_name#PROPAGATE_INTO_PREFIX_}
+        # Guard against empty target names
+        if [[ -n ${target_name} ]]; then
+            INPUT="export ${target_name}=${var_value}; ${INPUT}"
+        fi
+    fi
+done < <(env)   # feed the current environment to the while‑loop
+
 
 echo "Running '${INPUT}' in EESSI (${EESSI_CVMFS_REPO}) ${EESSI_VERSION} compatibility layer environment..."
 ${EESSI_COMPAT_LAYER_DIR}/startprefix <<< "${INPUT}"


### PR DESCRIPTION
This PR creates a generic way with which to prefix env vars so that they are propagated into the startprefix environment: you simply set `EESSI_PROPAGATE_INTO_PREFIX_X=val` to get a variable `X=val` defined within your startprefix environment.

This is useful for workarounds like the one that would be needed [here](https://github.com/EESSI/software-layer/pull/1524#issuecomment-4778635950), where we would want to set `export UCX_IB_GPU_DIRECT_RDMA=n` in the UGent bot's site configuration script. The current issue is that this doesn't get propagated _unless_ it is explicitely in the list of whitelisted variables in `run_in_compat_layer_env.sh`. However, it does not make any sense to put this variable in that list, since that propagation is only needed for the UGent bot. Moreover, it means that if you ever want to propagate a variable, you _always_ have to change the `run_in_compat_layer_env.sh` script first.

Having a long and specific enough prefix to the name of the env var allows us to specify such environment variables in the environment _outside_ of `startprefix`, yet make the `run_in_compat_layer_env.sh` automatically export these _inside_ the prefix.
