### PR TITLE
Fix and move copy_build_log function

### DIFF
--- a/EESSI-install-software.sh
+++ b/EESSI-install-software.sh
@@ -17,37 +17,6 @@ display_help() {
   echo "  --skip-cuda-install    -  disable installing a full CUDA SDK in the host_injections prefix (e.g. in CI)"
 }
 
-function copy_build_log() {
-    # copy specified build log to specified directory, with some context added
-    build_log=${1}
-    build_logs_dir=${2}
-
-    # also copy to build logs directory, if specified
-    if [ ! -z "${build_logs_dir}" ]; then
-        log_filename="$(basename ${build_log})"
-        if [ ! -z "${SLURM_JOB_ID}" ]; then
-            # use subdirectory for build log in context of a Slurm job
-            build_log_path="${build_logs_dir}/jobs/${SLURM_JOB_ID}/${log_filename}"
-        else
-            build_log_path="${build_logs_dir}/non-jobs/${log_filename}"
-        fi
-        mkdir -p $(dirname ${build_log_path})
-        cp -a ${build_log} ${build_log_path}
-        chmod 0644 ${build_log_path}
-
-        # add context to end of copied log file
-        echo >> ${build_log_path}
-        echo "Context from which build log was copied:" >> ${build_log_path}
-        echo "- original path of build log: ${build_log}" >> ${build_log_path}
-        echo "- working directory: ${PWD}" >> ${build_log_path}
-        echo "- Slurm job ID: ${SLURM_OUT}" >> ${build_log_path}
-        echo "- EasyBuild version: ${eb_version}" >> ${build_log_path}
-        echo "- easystack file: ${easystack_file}" >> ${build_log_path}
-
-        echo "EasyBuild log file ${build_log} copied to ${build_log_path} (with context appended)"
-    fi
-}
-
 function safe_module_use {
     # add a given non-empty directory to $MODULEPATH if and only if it is not yet in
     directory=${1}

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -197,3 +197,34 @@ function nvidia_gpu_has_compute_capability {
     fi
   fi
 }
+
+function copy_build_log() {
+    # copy specified build log to specified directory, with some context added
+    build_log=${1}
+    build_logs_dir=${2}
+
+    # also copy to build logs directory, if specified
+    if [ ! -z "${build_logs_dir}" ]; then
+        log_filename="$(basename ${build_log})"
+        if [ ! -z "${SLURM_JOB_ID}" ]; then
+            # use subdirectory for build log in context of a Slurm job
+            build_log_path="${build_logs_dir}/jobs/${SLURM_JOB_ID}/${log_filename}"
+        else
+            build_log_path="${build_logs_dir}/non-jobs/${log_filename}"
+        fi
+        mkdir -p $(dirname ${build_log_path})
+        cp -a ${build_log} ${build_log_path}
+        chmod 0644 ${build_log_path}
+
+        # add context to end of copied log file
+        echo >> ${build_log_path}
+        echo "Context from which build log was copied:" >> ${build_log_path}
+        echo "- original path of build log: ${build_log}" >> ${build_log_path}
+        echo "- working directory: ${PWD}" >> ${build_log_path}
+        echo "- Slurm job ID: ${SLURM_JOB_ID}" >> ${build_log_path}
+        echo "- EasyBuild version: ${eb_version}" >> ${build_log_path}
+        echo "- easystack file: ${easystack_file}" >> ${build_log_path}
+
+        echo "EasyBuild log file ${build_log} copied to ${build_log_path} (with context appended)"
+    fi
+}


### PR DESCRIPTION
We would also like to use this funtion in our local build bot at UGent so moving it helps us.

There is also an issue with the current funtion. It is not printing the job_id:
```
Context from which build log was copied:

- original path of build log: /tmp/eb-3wcdvarr/easybuild-4epar1do.log

- working directory: /eessi_bot_job

- Slurm job ID:

- EasyBuild version: 5.3.1

- easystack file: easystacks/software.eessi.io/2025.06/eessi-2025.06-eb-5.3.1-2025b.yml

```