### PR TITLE
Add AMD GPU accelerator detection to archdetect (+ CI tests)

### DIFF
--- a/.github/workflows/tests_archdetect_amd_gpu.yml
+++ b/.github/workflows/tests_archdetect_amd_gpu.yml
@@ -1,0 +1,112 @@
+# documentation: https://help.github.com/en/articles/workflow-syntax-for-github-actions
+name: Tests for accelerator detection (AMD GPU)
+on:
+  push:
+  pull_request:
+permissions:
+  contents: read # to fetch code (actions/checkout)
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    strategy:
+      matrix:
+        kfd_fixture:
+          - none # no KFD topology available
+          - no_devices # KFD topology present, but only a CPU node (no GPU)
+          - 1xmi250x # gfx90a
+          - 1xmi300x # gfx942
+          - 1xv710 # gfx1101 (AMD Radeon PRO V710)
+        EESSI_VERSION:
+          - '2023.06'
+      fail-fast: false
+    steps:
+    - name: checkout
+      uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+
+    # we deliberately do not use the eessi/github-action-eessi action,
+    # because we want to control when the EESSI environment is initialized
+    - name: Mount EESSI CernVM-FS repository
+      uses: cvmfs-contrib/github-action-cvmfs@55899ca74cf78ab874bdf47f5a804e47c198743c # v4.0
+      with:
+          cvmfs_config_package: https://github.com/EESSI/filesystem-layer/releases/download/latest/cvmfs-config-eessi_latest_all.deb
+          cvmfs_http_proxy: DIRECT
+          cvmfs_repositories: software.eessi.io
+
+    - name: Fix EESSI version in init scripts
+      run: |
+        sed -i "s/__EESSI_VERSION_DEFAULT__/${{matrix.EESSI_VERSION}}/g" init/eessi_defaults
+
+    - name: test accelerator detection
+      run: |
+          export EESSI_SOFTWARE_SUBDIR_OVERRIDE='x86_64/amd/zen2'
+
+          # point archdetect at a fake KFD topology tree (unless we want none at all)
+          if [[ "${{matrix.kfd_fixture}}" != "none" ]]; then
+              export EESSI_KFD_NODES_OVERRIDE="$PWD/tests/archdetect/amd-kfd/${{matrix.kfd_fixture}}/nodes"
+          else
+              export EESSI_KFD_NODES_OVERRIDE="$PWD/tests/archdetect/amd-kfd/does-not-exist/nodes"
+          fi
+
+          # first run with debugging enabled, just to show the output
+          ./init/eessi_archdetect.sh -d accelpath || echo "non-zero exit code: $?"
+
+          # verify output (or exit code if non-zero)
+          out=$(./init/eessi_archdetect.sh accelpath || echo "non-zero exit code: $?")
+
+          if [[ $out == "$( cat ./tests/archdetect/amd-kfd/${{matrix.kfd_fixture}}.output )" ]]; then
+
+              echo "Test for '${{matrix.kfd_fixture}}' PASSED: '$out'"
+
+              # run full EESSI init script, which picks up on the accelerator (if available)
+              echo
+              . init/bash 2>&1 | tee init.out
+              echo "-----------------------------------------------------------------------------"
+
+              if [[ "${{matrix.kfd_fixture}}" == "none" ]] || [[ "${{matrix.kfd_fixture}}" == "no_devices" ]]; then
+
+                  pattern="archdetect could not detect any accelerators"
+                  echo ">>> checking for pattern '${pattern}' in init output..."
+                  grep "${pattern}" init.out || (echo "FAILED 1" && exit 1)
+
+                  pattern="archdetect found supported accelerator"
+                  echo ">>> checking for lack of pattern '${pattern}' in init output..."
+                  match=$(grep "${pattern}" init.out || true)
+                  test "x${match}" = "x" || (echo "unexpected match found for '${pattern}' in init output" && exit 1)
+
+              else
+                  # no AMD accelerator stack exists in EESSI yet, so a detected AMD GPU
+                  # is expected to have no matching path under the CPU target
+                  accel=$(cat ./tests/archdetect/amd-kfd/${{matrix.kfd_fixture}}.output)
+                  pattern="No matching path found in x86_64/amd/zen2 for accelerator detected by archdetect (${accel})"
+                  echo ">>> checking for pattern '${pattern}' in init output..."
+                  grep "${pattern}" init.out || (echo "FAILED 1" && exit 1)
+
+                  pattern="Prepending /cvmfs/software.eessi.io/versions/${{matrix.EESSI_VERSION}}/software/linux/.*/accel/.*/modules/all to \$MODULEPATH"
+                  echo ">>> checking for lack of pattern '${pattern}' in init output..."
+                  match=$(grep "${pattern}" init.out || true)
+                  test "x${match}" = "x" || (echo "unexpected match found for '${pattern}' in init output" && exit 1)
+              fi
+
+              echo ">>> checking last line of init output..."
+              tail -1 init.out | grep "Environment set up to use EESSI (${{matrix.EESSI_VERSION}}), have fun!" || (echo "FAILED, full init output:" && cat init.out && exit 1)
+
+              echo "All checks on init output PASSED"
+          else
+              echo "Test for '${{matrix.kfd_fixture}}' FAILED: '$out'" >&2
+              exit 1
+          fi
+
+    - name: test accelerator detection under $EESSI_ACCEL_SOFTWARE_SUBDIR_OVERRIDE + $EESSI_ACCELERATOR_TARGET_OVERRIDE
+      run: |
+          export EESSI_SOFTWARE_SUBDIR_OVERRIDE='x86_64/amd/zen2'
+          export EESSI_ACCEL_SOFTWARE_SUBDIR_OVERRIDE='x86_64/amd/zen3'
+          export EESSI_ACCELERATOR_TARGET_OVERRIDE='accel/amd/gfx90a'
+
+          # first run with debugging enabled, just to show the output
+          ./init/eessi_archdetect.sh -d accelpath || echo "non-zero exit code: $?"
+
+          # verify the AMD override is accepted and echoed back verbatim
+          out=$(./init/eessi_archdetect.sh accelpath || echo "non-zero exit code: $?")
+          test "$out" = "accel/amd/gfx90a" || (echo "FAILED: unexpected accelpath output '$out'" && exit 1)
+
+          echo "All checks on AMD override PASSED"

--- a/.github/workflows/tests_archdetect_amd_gpu.yml
+++ b/.github/workflows/tests_archdetect_amd_gpu.yml
@@ -74,12 +74,14 @@ jobs:
                   test "x${match}" = "x" || (echo "unexpected match found for '${pattern}' in init output" && exit 1)
 
               else
-                  # no AMD accelerator stack exists in EESSI yet, so a detected AMD GPU
-                  # is expected to have no matching path under the CPU target
-                  accel=$(cat ./tests/archdetect/amd-kfd/${{matrix.kfd_fixture}}.output)
-                  pattern="No matching path found in x86_64/amd/zen2 for accelerator detected by archdetect (${accel})"
+                  # No AMD accelerator stack exists in EESSI yet, so a detected AMD GPU is
+                  # expected to have no matching path under the CPU target. The init script may
+                  # first map the detected target to its nearest supported base target (e.g.
+                  # gfx90a->gfx900, gfx942->gfx940, gfx1101->gfx1100), so match the "No matching
+                  # path found" line without pinning the exact gfx string.
+                  pattern="No matching path found in x86_64/amd/zen2 for accelerator detected by archdetect (accel/amd/gfx"
                   echo ">>> checking for pattern '${pattern}' in init output..."
-                  grep "${pattern}" init.out || (echo "FAILED 1" && exit 1)
+                  grep -F "${pattern}" init.out || (echo "FAILED 1" && exit 1)
 
                   pattern="Prepending /cvmfs/software.eessi.io/versions/${{matrix.EESSI_VERSION}}/software/linux/.*/accel/.*/modules/all to \$MODULEPATH"
                   echo ">>> checking for lack of pattern '${pattern}' in init output..."

--- a/init/eessi_archdetect.sh
+++ b/init/eessi_archdetect.sh
@@ -181,11 +181,106 @@ cpupath(){
     fi
 }
 
+nvidia_accelpath() {
+    # Check for NVIDIA GPUs via nvidia-smi command
+    local nvidia_smi
+    nvidia_smi=$(command -v nvidia-smi)
+    
+    if [[ $? -eq 0 ]]; then
+        log "DEBUG" "nvidia_accelpath: nvidia-smi command found @ ${nvidia_smi}"
+        local nvidia_smi_out
+        nvidia_smi_out=$(mktemp -p /tmp nvidia_smi_out.XXXXX)
+        
+        nvidia-smi --query-gpu=gpu_name,count,driver_version,compute_cap --format=csv,noheader 2>&1 > $nvidia_smi_out
+        if [[ $? -eq 0 ]]; then
+            local nvidia_smi_info=$(head -n 1 $nvidia_smi_out)
+            local cuda_cc=$(echo $nvidia_smi_info | sed 's/, /,/g' | cut -f4 -d, | sed 's/\.//g')
+            log "DEBUG" "nvidia_accelpath: CUDA compute capability '${cuda_cc}' derived from nvidia-smi output '${nvidia_smi_info}'"
+            
+            echo "accel/nvidia/cc${cuda_cc}"
+            rm -f $nvidia_smi_out
+            return 0
+        else
+            log "DEBUG" "nvidia_accelpath: nvidia-smi command failed, see output in $nvidia_smi_out"
+            return 3
+        fi
+    else
+        log "DEBUG" "nvidia_accelpath: nvidia-smi command not found"
+        return 2
+    fi
+}
+
+amd_accelpath() {
+    # Method 1: Check for AMD GPUs via KFD sysfs interface (No amd-smi or Python required)
+    local kfd_nodes="/sys/devices/virtual/kfd/kfd/topology/nodes"
+
+    if [[ -d "$kfd_nodes" ]]; then
+        log "DEBUG" "amd_accelpath: KFD sysfs path found @ ${kfd_nodes}"
+        local amdgcn_cc=""
+
+        # ls -1v ensures numeric/version sorting (nodes/0, nodes/1, ..., nodes/10)
+        for node in $(ls -1v "$kfd_nodes" 2>/dev/null); do
+            local prop_file="$kfd_nodes/$node/properties"
+            
+            if [[ -f "$prop_file" ]]; then
+                # Extract the integer value. 2>/dev/null suppresses read errors.
+                local gfx_ver=$(grep "^gfx_target_version" "$prop_file" 2>/dev/null | awk '{print $2}')
+                
+                # If gfx_ver is non-empty and greater than 0 (0 means it's a CPU node)
+                if [[ -n "$gfx_ver" && "$gfx_ver" -gt 0 ]]; then
+                    local major=$(( (gfx_ver / 10000) % 100 ))
+                    local minor=$(( (gfx_ver / 100) % 100 ))
+                    local step=$(( gfx_ver % 100 ))
+                    
+                    amdgcn_cc=$(printf "gfx%d%d%x" $major $minor $step)
+                    log "DEBUG" "amd_accelpath: AMDGCN compute capability '${amdgcn_cc}' derived from KFD node ${node}"
+                    break 
+                fi
+            fi
+        done
+
+        if [[ -n "$amdgcn_cc" ]]; then
+            echo "accel/amd/${amdgcn_cc}"
+            return 0
+        fi
+        log "DEBUG" "amd_accelpath: KFD topology found, but no AMD GPUs detected. Falling back to amd-smi."
+    else
+        log "DEBUG" "amd_accelpath: KFD sysfs path not found. Falling back to amd-smi."
+    fi
+
+    # Method 2: Fallback to AMD GPUs via amd-smi command using /tmp files
+    local amd_smi
+    amd_smi=$(command -v amd-smi)
+    
+    if [[ $? -eq 0 ]]; then
+        log "DEBUG" "amd_accelpath: amd-smi command found @ ${amd_smi}"
+        local amd_smi_out
+        amd_smi_out=$(mktemp -p /tmp amd_smi_out.XXXXX)
+        
+        amd-smi static --asic | grep TARGET_GRAPHICS_VERSION 2>&1 > $amd_smi_out
+        if [[ $? -eq 0 ]]; then
+            local amd_smi_info=$(head -n 1 $amd_smi_out)
+            local amdgcn_cc=$(echo $amd_smi_info | sed 's/.*: //')
+            log "DEBUG" "amd_accelpath: AMDGCN compute capability '${amdgcn_cc}' derived from amd-smi output '${amd_smi_info}'"
+            
+            echo "accel/amd/${amdgcn_cc}"
+            rm -f $amd_smi_out
+            return 0
+        else
+            log "DEBUG" "amd_accelpath: amd-smi command failed, see output in $amd_smi_out"
+            return 3
+        fi
+    else
+        log "DEBUG" "amd_accelpath: amd-smi command not found"
+        return 2
+    fi
+}
+
 accelpath() {
     # If EESSI_ACCELERATOR_TARGET_OVERRIDE is set, use it
     log "DEBUG" "accelpath: Override variable set as '$EESSI_ACCELERATOR_TARGET_OVERRIDE' "
     if [ ! -z $EESSI_ACCELERATOR_TARGET_OVERRIDE ]; then
-        # Regex that allows both NVIDIA and AMD overrides
+        # Updated regex to allow both NVIDIA and AMD overrides
         if [[ "$EESSI_ACCELERATOR_TARGET_OVERRIDE" =~ ^accel/(nvidia/cc[0-9]+|amd/gfx[0-9a-f]+)$ ]]; then
             echo "$EESSI_ACCELERATOR_TARGET_OVERRIDE"
             return 0
@@ -195,28 +290,27 @@ accelpath() {
         fi
     fi
 
-    # check for NVIDIA GPUs via nvidia-smi command
-    nvidia_smi=$(command -v nvidia-smi)
+    # 1. Check for NVIDIA GPUs
+    local nv_res
+    nv_res=$(nvidia_accelpath)
     if [[ $? -eq 0 ]]; then
-        log "DEBUG" "accelpath: nvidia-smi command found @ ${nvidia_smi}"
-        nvidia_smi_out=$(mktemp -p /tmp nvidia_smi_out.XXXXX)
-        nvidia-smi --query-gpu=gpu_name,count,driver_version,compute_cap --format=csv,noheader 2>&1 > $nvidia_smi_out
-        if [[ $? -eq 0 ]]; then
-            nvidia_smi_info=$(head -n 1 $nvidia_smi_out)
-            cuda_cc=$(echo $nvidia_smi_info | sed 's/, /,/g' | cut -f4 -d, | sed 's/\.//g')
-            log "DEBUG" "accelpath: CUDA compute capability '${cuda_cc}' derived from nvidia-smi output '${nvidia_smi_info}'"
-            res="accel/nvidia/cc${cuda_cc}"
-            log "DEBUG" "accelpath: result: ${res}"
-            echo $res
-            rm -f $nvidia_smi_out
-        else
-            log "DEBUG" "accelpath: nvidia-smi command failed, see output in $nvidia_smi_out"
-            exit 3
-        fi
-    else
-        log "DEBUG" "accelpath: nvidia-smi command not found"
-        exit 2
+        log "DEBUG" "accelpath: result: ${nv_res}"
+        echo "$nv_res"
+        return 0
     fi
+
+    # 2. Check for AMD GPUs
+    local amd_res
+    amd_res=$(amd_accelpath)
+    if [[ $? -eq 0 ]]; then
+        log "DEBUG" "accelpath: result: ${amd_res}"
+        echo "$amd_res"
+        return 0
+    fi
+
+    # 3. Fail gracefully if neither is found
+    log "DEBUG" "accelpath: No supported accelerators found on this system."
+    exit 2
 }
 
 # Parse command line arguments

--- a/init/eessi_archdetect.sh
+++ b/init/eessi_archdetect.sh
@@ -212,7 +212,8 @@ nvidia_accelpath() {
 
 amd_accelpath() {
     # Method 1: Check for AMD GPUs via KFD sysfs interface (No amd-smi or Python required)
-    local kfd_nodes="/sys/devices/virtual/kfd/kfd/topology/nodes"
+    # The base path can be overridden via $EESSI_KFD_NODES_OVERRIDE (used for testing with fixtures)
+    local kfd_nodes="${EESSI_KFD_NODES_OVERRIDE:-/sys/devices/virtual/kfd/kfd/topology/nodes}"
 
     if [[ -d "$kfd_nodes" ]]; then
         log "DEBUG" "amd_accelpath: KFD sysfs path found @ ${kfd_nodes}"

--- a/init/eessi_archdetect.sh
+++ b/init/eessi_archdetect.sh
@@ -292,24 +292,33 @@ accelpath() {
     fi
 
     # 1. Check for NVIDIA GPUs
-    local nv_res
+    local nv_res nv_rc
     nv_res=$(nvidia_accelpath)
-    if [[ $? -eq 0 ]]; then
+    nv_rc=$?
+    if [[ $nv_rc -eq 0 ]]; then
         log "DEBUG" "accelpath: result: ${nv_res}"
         echo "$nv_res"
         return 0
+    elif [[ $nv_rc -eq 3 ]]; then
+        # nvidia-smi is present but failed: treat as a hard error rather than
+        # silently falling through to other accelerator vendors
+        exit 3
     fi
 
     # 2. Check for AMD GPUs
-    local amd_res
+    local amd_res amd_rc
     amd_res=$(amd_accelpath)
-    if [[ $? -eq 0 ]]; then
+    amd_rc=$?
+    if [[ $amd_rc -eq 0 ]]; then
         log "DEBUG" "accelpath: result: ${amd_res}"
         echo "$amd_res"
         return 0
+    elif [[ $amd_rc -eq 3 ]]; then
+        # amd-smi is present but failed: treat as a hard error
+        exit 3
     fi
 
-    # 3. Fail gracefully if neither is found
+    # 3. Fail gracefully if no accelerator was found
     log "DEBUG" "accelpath: No supported accelerators found on this system."
     exit 2
 }

--- a/tests/archdetect/amd-kfd/1xmi250x.output
+++ b/tests/archdetect/amd-kfd/1xmi250x.output
@@ -1,0 +1,1 @@
+accel/amd/gfx90a

--- a/tests/archdetect/amd-kfd/1xmi250x/nodes/0/properties
+++ b/tests/archdetect/amd-kfd/1xmi250x/nodes/0/properties
@@ -1,0 +1,3 @@
+cpu_cores_count 128
+simd_count 0
+gfx_target_version 0

--- a/tests/archdetect/amd-kfd/1xmi250x/nodes/1/properties
+++ b/tests/archdetect/amd-kfd/1xmi250x/nodes/1/properties
@@ -1,0 +1,3 @@
+cpu_cores_count 0
+simd_count 4
+gfx_target_version 90010

--- a/tests/archdetect/amd-kfd/1xmi300x.output
+++ b/tests/archdetect/amd-kfd/1xmi300x.output
@@ -1,0 +1,1 @@
+accel/amd/gfx942

--- a/tests/archdetect/amd-kfd/1xmi300x/nodes/0/properties
+++ b/tests/archdetect/amd-kfd/1xmi300x/nodes/0/properties
@@ -1,0 +1,3 @@
+cpu_cores_count 128
+simd_count 0
+gfx_target_version 0

--- a/tests/archdetect/amd-kfd/1xmi300x/nodes/1/properties
+++ b/tests/archdetect/amd-kfd/1xmi300x/nodes/1/properties
@@ -1,0 +1,3 @@
+cpu_cores_count 0
+simd_count 4
+gfx_target_version 90402

--- a/tests/archdetect/amd-kfd/1xv710.output
+++ b/tests/archdetect/amd-kfd/1xv710.output
@@ -1,0 +1,1 @@
+accel/amd/gfx1101

--- a/tests/archdetect/amd-kfd/1xv710/nodes/0/properties
+++ b/tests/archdetect/amd-kfd/1xv710/nodes/0/properties
@@ -1,0 +1,3 @@
+cpu_cores_count 128
+simd_count 0
+gfx_target_version 0

--- a/tests/archdetect/amd-kfd/1xv710/nodes/1/properties
+++ b/tests/archdetect/amd-kfd/1xv710/nodes/1/properties
@@ -1,0 +1,3 @@
+cpu_cores_count 0
+simd_count 4
+gfx_target_version 110001

--- a/tests/archdetect/amd-kfd/no_devices.output
+++ b/tests/archdetect/amd-kfd/no_devices.output
@@ -1,0 +1,1 @@
+non-zero exit code: 2

--- a/tests/archdetect/amd-kfd/no_devices/nodes/0/properties
+++ b/tests/archdetect/amd-kfd/no_devices/nodes/0/properties
@@ -1,0 +1,3 @@
+cpu_cores_count 128
+simd_count 0
+gfx_target_version 0

--- a/tests/archdetect/amd-kfd/none.output
+++ b/tests/archdetect/amd-kfd/none.output
@@ -1,0 +1,1 @@
+non-zero exit code: 2


### PR DESCRIPTION
Completes the WIP AMD GPU accelerator detection from #205 and makes it testable in CI.

Builds on top of #205 (which refactors `accelpath()` into `nvidia_accelpath()` + `amd_accelpath()`, detects AMD GPUs via the KFD sysfs topology with an `amd-smi` fallback, and widens the override regex to accept `accel/amd/gfx<arch>`).

### What this PR adds on top of #205
- **Testability:** the KFD topology base path in `amd_accelpath()` can now be overridden via `$EESSI_KFD_NODES_OVERRIDE` (defaults to the real `/sys/devices/virtual/kfd/kfd/topology/nodes`). Without this the AMD detection path cannot be exercised in CI (it needs real AMD hardware + root).
- **Fixtures:** `tests/archdetect/amd-kfd/` KFD topology trees + expected outputs for:
  - `1xmi250x` → `accel/amd/gfx90a`
  - `1xmi300x` → `accel/amd/gfx942`
  - `1xv710` → `accel/amd/gfx1101` (AMD Radeon PRO V710)
  - `no_devices` (KFD present, CPU node only) → no accelerator
  - `none` (no KFD topology) → no accelerator
- **Workflow:** `tests_archdetect_amd_gpu.yml`, mirroring the existing NVIDIA GPU accelerator-detection workflow.

### Testing
Verified locally:
- KFD `gfx_target_version` → `gfx<arch>` decoding: `90010→gfx90a`, `90402→gfx942`, `110001→gfx1101`, `100300→gfx1030`.
- `accelpath` against every fixture (via `$EESSI_KFD_NODES_OVERRIDE`): all expected outputs; CPU-only / absent topology → exit 2.
- AMD override (`EESSI_ACCELERATOR_TARGET_OVERRIDE=accel/amd/gfx90a`) echoed back verbatim.
- `bash -n` clean; existing `cpupath` fixtures still pass (no regression).

The `. init/bash` CVMFS portion of the workflow runs only on the runner (no AMD stack exists in EESSI 2023.06 yet, so a detected AMD GPU is expected to find no matching module path — modelled on the existing NVIDIA `cc01` case).

### Notes
- The `amd-smi` fallback (Method 2, from #205) is not covered by fixtures — real `amd-smi` output format is uncertain; the KFD path is primary and tested.
- Supersedes #205.
