### PR TITLE
add pre-configure hook for PETSc to ensure that zlib is found in compat layer

### DIFF
--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -1402,6 +1402,19 @@ def pre_configure_hook_openmpi_ipv6(self, *args, **kwargs):
         raise EasyBuildError("OpenMPI-specific hook triggered for non-OpenMPI easyconfig?!")
 
 
+def pre_configure_hook_petsc(self, *args, **kwargs):
+    """
+    Pre-configure hook for PETSc
+    - make sure that zlib is found in compat layer
+    """
+    if self.name == 'PETSc':
+        # only necessary for PETSc 3.24.0+
+        if LooseVersion(self.version) >= LooseVersion('3.24.0'):
+            self.cfg.update('configopts', '--with-zlib-dir=${EESSI_EPREFIX}/usr')
+    else:
+        raise EasyBuildError("PETSc-specific hook triggered for non-PETSc easyconfig?!")
+
+
 def pre_configure_hook_pmix_ipv6(self, *args, **kwargs):
     """
     Pre-configure hook to enable IPv6 support in PMIx from EESSI 2025.06 onwards
@@ -2238,6 +2251,7 @@ PRE_CONFIGURE_HOOKS = {
     'MetaBAT': pre_configure_hook_metabat_filtered_zlib_dep,
     'OpenBLAS': pre_configure_hook_openblas_optarch_generic,
     'OpenMPI': pre_configure_hook_openmpi_ipv6,
+    'PETSc': pre_configure_hook_petsc,
     'PMIx': pre_configure_hook_pmix_ipv6,
     'PRRTE': pre_configure_hook_prrte_ipv6,
     'ROCm-LLVM': pre_configure_hook_llvm,


### PR DESCRIPTION
Without this, PETSc configure step for `PETSc-3.24.0-foss-2025b.eb` fails with:
```
  Package netcdf requested but dependency zlib not requested.
  Perhaps you want --download-zlib or --with-zlib-dir=directory or
  --with-zlib-lib=libraries and --with-zlib-include=directory
```

This happens because `zlib` is filtered out as dependency, and hence the PETSc easyblock won't automatically add `--with-zlib-dir` to the configure options

With this hook in place this is fixed, and PETSc configure step outputs:
```
zlib:
  Version:    1.3.1
  Includes:   -I/cvmfs/software.eessi.io/versions/2025.06/compat/linux/aarch64/usr/include
  Libraries:  -Wl,-rpath,/cvmfs/software.eessi.io/versions/2025.06/compat/linux/aarch64/usr/lib -L/cvmfs/software.eessi.io/versions/2025.06/compat/linux/aarch64/usr/lib -lz
```

I'm not sure why this is only required with PETSc 3.24.0+, this problem did not pop up for older PETSc versions (like 3.23.5)