### PR TITLE
extend configure options for SymEngine to make sure that binutils is found + GMP/MPC/MPFR dependencies are correctly picked up

### DIFF
--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -1222,10 +1222,14 @@ def pre_configure_hook_symengine(self, *args, **kwargs):
         res = glob.glob(libbfd_path_pattern)
         if res:
             libbfd_path = res[0]
-            bfd_include_path = os.path.join(os.path.dirname(libbfd_path), 'include')
+            bfd_topdir = os.path.dirname(libbfd_path)
+            bfd_include_path = os.path.join(bfd_topdir, 'include')
             if os.path.isdir(bfd_include_path):
                 self.cfg.update('configopts', f"-DBFD_INCLUDE_DIR={bfd_include_path}")
                 self.cfg.update('configopts', f"-DBFD_LIBRARY={libbfd_path}")
+                # add path to libbfd.so to $LIBRARY_PATH, so it gets added to RPATH section
+                library_path = os.getenv('LIBRARY_PATH')
+                os.environ['LIBRARY_PATH'] = f'{library_path}:{bfd_topdir}'
             else:
                 raise EasyBuildError(f"binutils include path {bfd_include_path} does not exist?!")
         else:

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -244,7 +244,7 @@ def get_eessi_envvar(eessi_envvar):
 def get_rpath_override_dirs(software_name=None, stub_suffix=""):
     if software_name is None:
         raise EasyBuildError("This function should not be called without setting software_name")
-    
+
     # determine path to installations in software layer via $EESSI_SOFTWARE_PATH
     eessi_software_path = get_eessi_envvar('EESSI_SOFTWARE_PATH')
 
@@ -1208,6 +1208,41 @@ def pre_configure_hook_score_p(self, *args, **kwargs):
         raise EasyBuildError("Score-P-specific hook triggered for non-Score-P easyconfig?!")
 
 
+def pre_configure_hook_symengine(self, *args, **kwargs):
+    """
+    Pre-configure hook for SymEngine
+    """
+    if self.name == 'SymEngine':
+        # make sure that BFD (part of binutils) is found;
+        # full path depends on EESSI version and CPU family,
+        # something like ${EESSI_PREFIX}/usr/lib64/binutils/aarch64-unknown-linux-gnu/2.44/*
+        # or ${EESSI_PREFIX}/usr/lib64/binutils/x86_64-pc-linux-gnu/2.44/*
+        compat_layer_topdir = get_eessi_envvar('EESSI_EPREFIX')
+        libbfd_path_pattern = os.path.join(compat_layer_topdir, 'usr', 'lib64', 'binutils', '*-linux-gnu', '*', 'libbfd.so')
+        res = glob.glob(libbfd_path_pattern)
+        if res:
+            libbfd_path = res[0]
+            bfd_include_path = os.path.join(os.path.dirname(libbfd_path), 'include')
+            if os.path.isdir(bfd_include_path):
+                self.cfg.update('configopts', f"-DBFD_INCLUDE_DIR={bfd_include_path}")
+                self.cfg.update('configopts', f"-DBFD_LIBRARY={libbfd_path}")
+            else:
+                raise EasyBuildError(f"binutils include path {bfd_include_path} does not exist?!")
+        else:
+            raise EasyBuildError(f"No match found for {libbfd_path_pattern}")
+
+        # make sure correct installation of GMP/MPC/MPFR is picked up (from dependencies, not compat layer)
+        for dep in ('GMP', 'MPC', 'MPFR'):
+            dep_installdir = get_software_root(dep)
+            if dep_installdir:
+                self.cfg.update('configopts', f"-D{dep}_INCLUDE_DIR={dep_installdir}/include")
+                self.cfg.update('configopts', f"-D{dep}_LIBRARY={dep_installdir}/lib/lib{dep.lower()}.so")
+            else:
+                raise EasyBuildError(f"Path for {dep} installaiton directory not found")
+    else:
+        raise EasyBuildError("SymEngine-specific hook triggered for non-SymEngine easyconfig?!")
+
+
 def pre_configure_hook_dyninst(self, *args, **kwargs):
     """
     Pre-configure hook for Dyninst
@@ -1757,9 +1792,9 @@ def pre_test_hook_Siesta_ignore_failure_with_crosscompilation(self, *args, **kwa
     """
     Ignore failing tests when crosscompiling without gpu present.
     """
-    if self.name == 'Siesta': 
+    if self.name == 'Siesta':
         if self.version in ['5.4.2']:
-            if 'CUDA' in self.cfg['versionsuffix']: 
+            if 'CUDA' in self.cfg['versionsuffix']:
                 cuda_cc = build_option('cuda_compute_capabilities')
                 if cuda_cc and not get_gpu_info():
                     failing_tests=[
@@ -2065,7 +2100,7 @@ def find_rocm_llvm_dependency(ec):
     for dep in tcdeps:
         if dep['name'] == 'ROCm-LLVM':
             return dep
-    # For rompi, rfbf, rfoss, ROCm-LLVM is pulled in indirectly via rocm-compilers. the rocm-compilers 
+    # For rompi, rfbf, rfoss, ROCm-LLVM is pulled in indirectly via rocm-compilers. the rocm-compilers
     # toolchain dependency already encodes the ROCm version in its version string (e.g. '19.0.0-ROCm-6.4.1')
     rocm_prefix = '-ROCm-'
     for dep in tcdeps:
@@ -2091,7 +2126,7 @@ def inject_gpu_property(ec):
 
     pkg_versions = { }
     add_gpu_property = ''
-    
+
     # Packages that define the accelerator ecosystem
     top_level_accelerator_packages = ["CUDA", "ROCm"]
     # Create a dependency property in the easyconfig instance that provides
@@ -2242,6 +2277,7 @@ PRE_CONFIGURE_HOOKS = {
     'PRRTE': pre_configure_hook_prrte_ipv6,
     'ROCm-LLVM': pre_configure_hook_llvm,
     'Score-P': pre_configure_hook_score_p,
+    'SymEngine': pre_configure_hook_symengine,
     'WRF': pre_configure_hook_wrf_aarch64,
     'Zoltan': pre_configure_hook_Zoltan,
 }


### PR DESCRIPTION
fix for:
```
CMake Error at /cvmfs/software.eessi.io/versions/2025.06/software/linux/aarch64/neoverse_v1/software/CMake/4.0.3-GCCcore-14.3.0/share/cmake-4.0/Modules/FindPackageHandleStandardArgs.cmake:227 (message):
                                       Could NOT find BFD (missing: BFD_INCLUDE_DIRS)
```

In addition, GMP & co were being picked up from the compat layer, as shown in output produced by `cmake`:

```
-- Found MPC: /cvmfs/software.eessi.io/versions/2025.06/compat/linux/aarch64/usr/lib64/libmpc.so
-- Found MPFR: /cvmfs/software.eessi.io/versions/2025.06/compat/linux/aarch64/usr/lib64/libmpfr.so
-- Found GMP: /cvmfs/software.eessi.io/versions/2025.06/compat/linux/aarch64/usr/lib64/libgmp.so
```

That's fixed by specifying the location of these dependencies explicitly.

Tested updated hooks with `EESSI-extend`, installing `SymEngine-0.14.0-gfbf-2025b.eb` works like a charm now...