### PR TITLE
fix post_easyblock_hook_copy_easybuild_subdir: check that `easybuild` subdirectory exists before trying to copy it to reprod directory

### DIFF
--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -961,7 +961,12 @@ def post_easyblock_hook_copy_easybuild_subdir(self, *args, **kwargs):
     now_utc_timestamp = datetime.datetime.now(datetime.UTC).strftime('%Y%m%d_%H%M%S%Z')
     app_easybuild_dir = os.path.join(self.installdir, config.log_path(ec=self.cfg))
     app_reprod_dir = os.path.join(stack_reprod_dir, self.install_subdir, now_utc_timestamp, 'easybuild')
-    copy_dir(app_easybuild_dir, app_reprod_dir)
+    # take into account that 'easybuild' subdirectory may not exist yet,
+    # for example in case of installations that failed because source files could not be downloaded
+    if os.path.exists(app_easybuild_dir):
+        copy_dir(app_easybuild_dir, app_reprod_dir)
+    else:
+        self.log.warning(f"{app_easybuild_dir} was *not* copied to {app_reprod_dir}, because it does not exist!")
 
 
 def pre_prepare_hook_cuda_dependant(self, *args, **kwargs):


### PR DESCRIPTION
This avoids a confusing "`Failed to copy directory`" error message when an installation failed because downloading of source files files, for example:
```
== 2026-07-30 13:31:38,659 build_log.py:233 ERROR EasyBuild encountered an error: Failed to copy directory /cvmfs/software.eessi.io/versions/2025.06/software/linux/x86_64/amd/zen5/software/nettle/3.10.1-GCCcore-14.2.0/easybuild to /cvmfs/s
oftware.eessi.io/versions/2025.06/software/linux/x86_64/amd/zen5/reprod/nettle/3.10.1-GCCcore-14.2.0/20260730_133138UTC/easybuild: [Errno 2] No such file or directory: '/cvmfs/software.eessi.io/versions/2025.06/software/linux/x86_64/amd/ze
n5/software/nettle/3.10.1-GCCcore-14.2.0/easybuild' (at easybuild/tools/filetools.py:2738 in copy_dir)
Callstack:
        easybuild/tools/filetools.py:2738 in copy_dir
        easybuild/eb_hooks.py:964 in post_easyblock_hook_copy_easybuild_subdir
        easybuild/eb_hooks.py:2199 in post_easyblock_hook
        easybuild/tools/hooks.py:252 in run_hook
        easybuild/framework/easyblock.py:5365 in build_and_install_one
        easybuild/main.py:184 in build_and_install_software
        easybuild/main.py:630 in process_eb_args
        easybuild/main.py:337 in process_easystack
        easybuild/main.py:812 in main
        easybuild/main.py:872 in main_with_hooks
        easybuild/main.py:891 in <module>
```

While the actual problem (higher up in the log) is a download failure:
```
== 2026-07-30 14:13:03,592 build_log.py:233 ERROR EasyBuild encountered an error: Couldn't find file nettle-3.10.1.tar.gz anywhere, and downloading it didn't work either...
```