### PR TITLE
Restrict Perl hook to EESSI 2026.06, also apply it to Perl 5.38.0

### DIFF
--- a/easystacks/software.eessi.io/2026.06/eessi-2026.06-eb-5.3.1-perl.yml
+++ b/easystacks/software.eessi.io/2026.06/eessi-2026.06-eb-5.3.1-perl.yml
@@ -1,0 +1,2 @@
+easyconfigs:
+  - Perl-5.38.0.eb

--- a/easystacks/software.eessi.io/2026.06/eessi-2026.06-eb-5.3.1-perl.yml
+++ b/easystacks/software.eessi.io/2026.06/eessi-2026.06-eb-5.3.1-perl.yml
@@ -1,2 +1,0 @@
-easyconfigs:
-  - Perl-5.38.0.eb

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -1686,12 +1686,13 @@ def pre_test_hook_lammps_ignore_failure_arm_generic(self, *args, **kwargs):
 
 def pre_test_hook_perl_increase_test_timeout(self, *args, **kwargs):
     """
-    Tests fail for Perl v5.42.0 when run with standard timeout. So, increase timeout by a factor of 10.
+    Tests fail for certain Perl versions when run with standard timeout. So, increase timeout by a factor of 10.
     See https://github.com/EESSI/software-layer/pull/1556#issuecomment-5183283054
     """
-    if self.name == "Perl" and self.version == "5.42.0":
-        # increase timeout for Perl tests, to avoid flaky failures in tests like dist/threads/t/libc.t
-        env.setvar('PERL_TEST_TIME_OUT_FACTOR', '10')
+    if self.name == "Perl":
+        if self.version == "5.42.0" or (self.version == "5.38.0" and is_system_toolchain(self.toolchain.name)):
+            # increase timeout for Perl tests, to avoid flaky failures in tests like dist/threads/t/libc.t
+            env.setvar('PERL_TEST_TIME_OUT_FACTOR', '10')
 
 def pre_test_hook_ignore_failing_tests_SciPybundle(self, *args, **kwargs):
     """

--- a/eb_hooks.py
+++ b/eb_hooks.py
@@ -1686,13 +1686,15 @@ def pre_test_hook_lammps_ignore_failure_arm_generic(self, *args, **kwargs):
 
 def pre_test_hook_perl_increase_test_timeout(self, *args, **kwargs):
     """
-    Tests fail for certain Perl versions when run with standard timeout. So, increase timeout by a factor of 10.
+    Tests fail for different Perl versions in EESSI 2026.06 when run with standard timeout. So, increase timeout by a factor of 10.
     See https://github.com/EESSI/software-layer/pull/1556#issuecomment-5183283054
     """
-    if self.name == "Perl":
-        if self.version == "5.42.0" or (self.version == "5.38.0" and is_system_toolchain(self.toolchain.name)):
-            # increase timeout for Perl tests, to avoid flaky failures in tests like dist/threads/t/libc.t
-            env.setvar('PERL_TEST_TIME_OUT_FACTOR', '10')
+    eessi_version = get_eessi_envvar('EESSI_VERSION')
+    if self.name == 'Perl':
+        if eessi_version == '2026.06':
+            if self.version in ['5.38.0', '5.42.0']:
+                # increase timeout for Perl tests, to avoid flaky failures in tests like dist/threads/t/libc.t
+                env.setvar('PERL_TEST_TIME_OUT_FACTOR', '10')
 
 def pre_test_hook_ignore_failing_tests_SciPybundle(self, *args, **kwargs):
     """


### PR DESCRIPTION
Didn't want to use a too big hammer, as Perl 5.38.0 with SYSTEM toolchain is also part of EESSI 2025.06, and we didn't see any issues there. So I've restricted it to EESSI 2026.06 and specific Perl versions.