### PR TITLE
Fetch all source files before processing easystack file

### DIFF
--- a/EESSI-install-software.sh
+++ b/EESSI-install-software.sh
@@ -430,13 +430,16 @@ else
             echo_green "All set, let's start installing some software with EasyBuild v${eb_version} in ${EASYBUILD_INSTALLPATH}..."
 
             if [ -f ${easystack_file} ]; then
-                echo_green "Downloading sources for easystack file ${easystack_file}..."
-                # run eb --help to determine if --fetch-all is supported (available since 5.3.0), otherwise fall back to --fetch
-                fetch_option="--fetch"
-                ${EB} --help | grep -q -e "fetch-all" && fetch_option="--fetch-all"
-                ${EB} ${fetch_option} --easystack ${easystack_file} --robot
-                if [ $? -ne 0 ]; then
-                    fatal_error "Could not download all required source files for this easystack file."
+                if [ -z $EESSI_SKIP_FETCH_EASYSTACK_SOURCES ]; then
+                    # run eb --help to determine if --fetch-all is supported (available since 5.3.0), otherwise fall back to --fetch
+                    fetch_option="--fetch"
+                    ${EB} --help | grep -q -e "fetch-all" && fetch_option="--fetch-all"
+                    echo_green "Downloading sources for easystack file ${easystack_file} using eb ${fetch_option}..."
+                    echo "(note: this step can be skipped by setting $EESSI_SKIP_FETCH_EASYSTACK_SOURCES to a non-empty value)"
+                    ${EB} ${fetch_option} --easystack ${easystack_file} --robot
+                    if [ $? -ne 0 ]; then
+                        fatal_error "Could not download all required source files for this easystack file."
+                    fi
                 fi
 
                 echo_green "Feeding easystack file ${easystack_file} to EasyBuild..."

--- a/EESSI-install-software.sh
+++ b/EESSI-install-software.sh
@@ -430,6 +430,12 @@ else
             echo_green "All set, let's start installing some software with EasyBuild v${eb_version} in ${EASYBUILD_INSTALLPATH}..."
 
             if [ -f ${easystack_file} ]; then
+                echo_green "Downloading sources for easystack file ${easystack_file}..."
+                ${EB} --fetch-all --easystack ${easystack_file} --robot
+                if [ $? -ne 0 ]; then
+                    fatal_error "Could not download all required source files for this easystack file."
+                fi
+
                 echo_green "Feeding easystack file ${easystack_file} to EasyBuild..."
 
                 if [[ ${easystack_file} == *"/rebuilds/"* ]]; then

--- a/EESSI-install-software.sh
+++ b/EESSI-install-software.sh
@@ -431,7 +431,10 @@ else
 
             if [ -f ${easystack_file} ]; then
                 echo_green "Downloading sources for easystack file ${easystack_file}..."
-                ${EB} --fetch-all --easystack ${easystack_file} --robot
+                # run eb --help to determine if --fetch-all is supported (available since 5.3.0), otherwise fall back to --fetch
+                fetch_option="--fetch"
+                ${EB} --help | grep -q -e "fetch-all" && fetch_option="--fetch-all"
+                ${EB} ${fetch_option} --easystack ${easystack_file} --robot
                 if [ $? -ne 0 ]; then
                     fatal_error "Could not download all required source files for this easystack file."
                 fi

--- a/easystacks/software.eessi.io/2026.06/eessi-2026.06-eb-5.3.1-test.yml
+++ b/easystacks/software.eessi.io/2026.06/eessi-2026.06-eb-5.3.1-test.yml
@@ -1,4 +1,6 @@
 easyconfigs:
   - Automake-1.16.5.eb
   - Automake-1.18.1-GCCcore-15.2.0.eb
-  - parallel-20260522-GCCcore-15.2.0.eb
+  - parallel-20260522-GCCcore-15.2.0.eb:
+      options:
+        from-commit: cf3efa2000133a41fca32162f8de24a7cfda0a7d

--- a/easystacks/software.eessi.io/2026.06/eessi-2026.06-eb-5.3.1-test.yml
+++ b/easystacks/software.eessi.io/2026.06/eessi-2026.06-eb-5.3.1-test.yml
@@ -1,2 +1,0 @@
-easyconfigs:
-  - Automake-1.18.1-GCCcore-15.2.0.eb

--- a/easystacks/software.eessi.io/2026.06/eessi-2026.06-eb-5.3.1-test.yml
+++ b/easystacks/software.eessi.io/2026.06/eessi-2026.06-eb-5.3.1-test.yml
@@ -1,0 +1,4 @@
+easyconfigs:
+  - Automake-1.16.5.eb
+  - Automake-1.18.1-GCCcore-15.2.0.eb
+  - parallel-20260522-GCCcore-15.2.0.eb

--- a/easystacks/software.eessi.io/2026.06/eessi-2026.06-eb-5.3.1-test.yml
+++ b/easystacks/software.eessi.io/2026.06/eessi-2026.06-eb-5.3.1-test.yml
@@ -1,3 +1,2 @@
 easyconfigs:
-  - Automake-1.16.5.eb
   - Automake-1.18.1-GCCcore-15.2.0.eb

--- a/easystacks/software.eessi.io/2026.06/eessi-2026.06-eb-5.3.1-test.yml
+++ b/easystacks/software.eessi.io/2026.06/eessi-2026.06-eb-5.3.1-test.yml
@@ -1,6 +1,3 @@
 easyconfigs:
   - Automake-1.16.5.eb
   - Automake-1.18.1-GCCcore-15.2.0.eb
-  - parallel-20260522-GCCcore-15.2.0.eb:
-      options:
-        from-commit: cf3efa2000133a41fca32162f8de24a7cfda0a7d


### PR DESCRIPTION
This should make it fail early in case source tarballs cannot be downloaded. Note that if you're processing multiple easystack files, it will not fetch the sources for all of them. Doing that would require more changes to the code, and we're not doing that very often anyway: almost all PRs change only one easystack file, so this should already be a big improvement.

I'll give it a try with an actual easystack file.